### PR TITLE
Release v0.2.0

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -17,10 +17,12 @@ DISCORD_TOKEN=your_discord_bot_token_here
 # ========================================
 # SLACK_BOT_TOKEN=xoxb-your-bot-token
 # SLACK_APP_TOKEN=xapp-your-app-token
-# SLACK_SIGNING_SECRET=your-signing-secret
 
 # Optional: Slack channels where bot responds without mention
 # SLACK_AUTO_REPLY_CHANNELS=C01234567,C89012345
+
+# Optional: Reply in channel instead of thread (default: true = thread)
+# SLACK_REPLY_IN_THREAD=false
 
 # ========================================
 # 許可ユーザー設定（各プラットフォームで1人のみ）

--- a/Dockerfile.max
+++ b/Dockerfile.max
@@ -1,0 +1,58 @@
+# Stage 1: Build
+FROM node:22-slim AS builder
+
+WORKDIR /app
+
+COPY package*.json ./
+RUN npm ci
+
+COPY tsconfig.json ./
+COPY src/ ./src/
+RUN npm run build
+
+# Stage 2: Production (Full version with uv + Python)
+FROM node:22-slim
+
+# Install dependencies for Claude Code CLI, GitHub CLI, and Python
+RUN apt-get update && apt-get install -y \
+    curl \
+    git \
+    ca-certificates \
+    && curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg | dd of=/usr/share/keyrings/githubcli-archive-keyring.gpg \
+    && chmod go+r /usr/share/keyrings/githubcli-archive-keyring.gpg \
+    && echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" | tee /etc/apt/sources.list.d/github-cli.list > /dev/null \
+    && apt-get update && apt-get install -y gh \
+    && rm -rf /var/lib/apt/lists/*
+
+# Copy uv binary from official image
+COPY --from=ghcr.io/astral-sh/uv:latest /uv /usr/local/bin/uv
+
+# Install Python via uv
+RUN uv python install 3.12
+
+WORKDIR /app
+
+# Copy package files and install production dependencies
+COPY package*.json ./
+RUN npm ci --omit=dev --ignore-scripts
+
+# Copy built files from builder stage
+COPY --from=builder /app/dist ./dist
+
+# Install Codex CLI globally (as root)
+RUN npm install -g @openai/codex
+
+# Create directories for node user
+RUN mkdir -p /home/node/.config/gh && chown -R node:node /home/node/.config
+
+# Switch to node user for Claude Code CLI installation
+USER node
+
+# Install Claude Code CLI as node user
+RUN curl -fsSL https://claude.ai/install.sh | bash
+
+# Add Claude, Codex, and uv to PATH
+ENV PATH="/home/node/.local/bin:/root/.local/bin:${PATH}"
+
+# Default command
+CMD ["node", "dist/index.js"]

--- a/README.md
+++ b/README.md
@@ -31,9 +31,17 @@ cp .env.example .env
 
 ### 2. 起動
 
+**ミニマム版（デフォルト）:**
 ```bash
-docker compose up -d --build
+docker compose up xangi -d --build
 ```
+
+**フル版（uv + Python 3.12 入り）:**
+```bash
+docker compose up xangi-max -d --build
+```
+
+フル版は `uv` コマンドで Python パッケージを管理できます。
 
 ### 3. AI CLI認証（コンテナ内）
 
@@ -60,15 +68,67 @@ docker exec -it xangi codex login --device-auth
 
 ### 4. GitHub CLI認証（オプション）
 
+ホストで `gh` が認証済みなら、トークンを `.env` に追加するだけでOK:
+
 ```bash
-docker exec -it xangi gh auth login
+echo "GH_TOKEN=$(gh auth token)" >> .env
 ```
 
-ブラウザ認証またはトークン入力で認証。ghコマンドが使えるようになります。
+その後コンテナを再起動:
+```bash
+docker compose up -d
+```
+
+**確認:**
+```bash
+docker exec xangi gh auth status
+```
 
 ### 5. 動作確認
 
 Discord/Slackでbotにメンションして話しかけてください。
+
+## ローカル実行（非推奨）
+
+Docker を使わずにホストで直接実行する方法。環境の分離ができないため非推奨。
+
+### 事前準備
+
+```bash
+# Node.js 22+ が必要
+node -v
+
+# Claude Code CLI
+curl -fsSL https://claude.ai/install.sh | bash
+
+# Codex CLI（AGENT_BACKEND=codex の場合）
+npm install -g @openai/codex
+```
+
+### ビルド & 起動
+
+```bash
+cd /path/to/xangi-dev
+npm install
+npm run build
+
+# .env を読み込んで起動
+node --env-file=.env dist/index.js
+```
+
+### 開発時
+
+```bash
+npm run dev
+```
+
+### 作業ディレクトリの設定
+
+Claude Code を実行するディレクトリを指定:
+
+```bash
+export WORKSPACE_PATH=/path/to/workspace
+```
 
 ## 使い方
 
@@ -108,7 +168,6 @@ Discord/Slackでbotにメンションして話しかけてください。
 |------|------|
 | `SLACK_BOT_TOKEN` | Slack Bot Token（xoxb-...） |
 | `SLACK_APP_TOKEN` | Slack App Token（xapp-...）※Socket Mode用 |
-| `SLACK_SIGNING_SECRET` | Slack Signing Secret |
 | `SLACK_AUTO_REPLY_CHANNELS` | メンションなしで応答するチャンネルID（カンマ区切り） |
 | `SLACK_ALLOWED_USER` | Slack用の許可ユーザーID |
 | `SLACK_REPLY_IN_THREAD` | スレッド返信するか（デフォルト: `true`） |
@@ -126,6 +185,32 @@ Discord/Slackでbotにメンションして話しかけてください。
 | `TIMEOUT_MS` | タイムアウト（デフォルト: 300000 = 5分） |
 
 **注意:** Discord または Slack のどちらか一方のTokenが必要です（両方設定すれば両方起動）。
+
+## IDの調べ方
+
+### Discord
+
+**ユーザーID:**
+1. Discord設定 → 詳細設定 → **開発者モード** を ON
+2. ユーザーを右クリック → **「ユーザーIDをコピー」**
+
+**チャンネルID:**
+1. 開発者モードを ON にした状態で
+2. チャンネルを右クリック → **「チャンネルIDをコピー」**
+
+### Slack
+
+**ユーザーID:**
+1. ユーザーのプロフィールを開く
+2. **「︙」**（その他）→ **「メンバーIDをコピー」**
+
+**チャンネルID:**
+1. チャンネル名を右クリック → **「リンクをコピー」**
+2. URLの末尾がチャンネルID: `https://xxx.slack.com/archives/C01234567` ← `C01234567` がID
+
+または:
+1. チャンネルを開く → チャンネル名をクリック
+2. 一番下に **チャンネルID** が表示される
 
 ## マウント設定
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,42 +1,54 @@
+# 共通設定
+x-common: &common
+  restart: unless-stopped
+  volumes:
+    # Claude Code CLI 認証情報（コンテナ専用ボリューム）
+    - claude-data:/home/node/.claude
+    # Codex CLI 認証情報（コンテナ専用ボリューム）
+    - codex-data:/home/node/.codex
+    # ワークスペース（エージェントの作業ディレクトリ）
+    - ${WORKSPACE_PATH:-./workspace}:/workspace
+    # Git設定
+    - ~/.gitconfig:/home/node/.gitconfig:ro
+  environment: &common-env
+    # GitHub CLI (GH_TOKEN環境変数で認証)
+    - GH_TOKEN=${GH_TOKEN:-}
+    - NODE_ENV=production
+    # Discord
+    - DISCORD_TOKEN=${DISCORD_TOKEN:-}
+    - AUTO_REPLY_CHANNELS=${AUTO_REPLY_CHANNELS:-}
+    - DISCORD_STREAMING=${DISCORD_STREAMING:-true}
+    - DISCORD_SHOW_THINKING=${DISCORD_SHOW_THINKING:-true}
+    # Slack
+    - SLACK_BOT_TOKEN=${SLACK_BOT_TOKEN:-}
+    - SLACK_APP_TOKEN=${SLACK_APP_TOKEN:-}
+    - SLACK_AUTO_REPLY_CHANNELS=${SLACK_AUTO_REPLY_CHANNELS:-}
+    - SLACK_REPLY_IN_THREAD=${SLACK_REPLY_IN_THREAD:-true}
+    - SLACK_STREAMING=${SLACK_STREAMING:-true}
+    - SLACK_SHOW_THINKING=${SLACK_SHOW_THINKING:-true}
+    # Common
+    - DISCORD_ALLOWED_USER=${DISCORD_ALLOWED_USER:-}
+    - SLACK_ALLOWED_USER=${SLACK_ALLOWED_USER:-}
+    - WORKSPACE_PATH=/workspace
+    - SKIP_PERMISSIONS=${SKIP_PERMISSIONS:-false}
+    # Agent
+    - AGENT_BACKEND=${AGENT_BACKEND:-claude-code}
+    - AGENT_MODEL=${AGENT_MODEL:-}
+
 services:
+  # ミニマム版（デフォルト）
   xangi:
+    <<: *common
     build: .
     container_name: xangi
-    restart: unless-stopped
-    volumes:
-      # Claude Code CLI 認証情報（コンテナ専用ボリューム）
-      - claude-data:/home/node/.claude
-      # Codex CLI 認証情報（コンテナ専用ボリューム）
-      - codex-data:/home/node/.codex
-      # ワークスペース（エージェントの作業ディレクトリ）
-      - ${WORKSPACE_PATH:-./workspace}:/workspace
-      # Git設定
-      - ~/.gitconfig:/home/node/.gitconfig:ro
-    environment:
-      # GitHub CLI (GH_TOKEN環境変数で認証)
-      - GH_TOKEN=${GH_TOKEN:-}
-      - NODE_ENV=production
-      # Discord
-      - DISCORD_TOKEN=${DISCORD_TOKEN:-}
-      - AUTO_REPLY_CHANNELS=${AUTO_REPLY_CHANNELS:-}
-      - DISCORD_STREAMING=${DISCORD_STREAMING:-true}
-      - DISCORD_SHOW_THINKING=${DISCORD_SHOW_THINKING:-true}
-      # Slack
-      - SLACK_BOT_TOKEN=${SLACK_BOT_TOKEN:-}
-      - SLACK_APP_TOKEN=${SLACK_APP_TOKEN:-}
-      - SLACK_SIGNING_SECRET=${SLACK_SIGNING_SECRET:-}
-      - SLACK_AUTO_REPLY_CHANNELS=${SLACK_AUTO_REPLY_CHANNELS:-}
-      - SLACK_REPLY_IN_THREAD=${SLACK_REPLY_IN_THREAD:-true}
-      - SLACK_STREAMING=${SLACK_STREAMING:-true}
-      - SLACK_SHOW_THINKING=${SLACK_SHOW_THINKING:-true}
-      # Common
-      - DISCORD_ALLOWED_USER=${DISCORD_ALLOWED_USER}
-      - SLACK_ALLOWED_USER=${SLACK_ALLOWED_USER:-}
-      - WORKSPACE_PATH=/workspace
-      - SKIP_PERMISSIONS=${SKIP_PERMISSIONS:-false}
-      # Agent
-      - AGENT_BACKEND=${AGENT_BACKEND:-claude-code}
-      - AGENT_MODEL=${AGENT_MODEL:-}
+
+  # フル版（uv + Python）
+  xangi-max:
+    <<: *common
+    build:
+      context: .
+      dockerfile: Dockerfile.max
+    container_name: xangi-max
 
 volumes:
   claude-data:

--- a/docs/discord-setup.md
+++ b/docs/discord-setup.md
@@ -1,6 +1,6 @@
 # Discord Bot セットアップガイド
 
-kbot を Discord で使用するための Bot 作成手順。
+xangi を Discord で使用するための Bot 作成手順。
 
 ## 1. Discord Developer Portal にアクセス
 
@@ -11,7 +11,7 @@ Discord アカウントでログイン。
 ## 2. 新しいアプリケーション作成
 
 1. 右上の **「New Application」** をクリック
-2. 名前を入力: `kbot`（任意の名前）
+2. 名前を入力: `xangi`（任意の名前）
 3. **「Create」** をクリック
 
 ## 3. Bot 作成とトークン取得
@@ -75,12 +75,12 @@ npm run build
 docker compose up -d --build
 
 # ログ確認
-docker logs -f kbot
+docker logs -f xangi
 ```
 
 Discord サーバーで `/new` や `/skills` を試す、または Bot をメンションして話しかける：
 ```
-@kbot こんにちは！
+@xangi こんにちは！
 ```
 
 ## ユーザー ID の取得方法

--- a/docs/slack-setup.md
+++ b/docs/slack-setup.md
@@ -1,6 +1,6 @@
 # Slack App セットアップガイド
 
-kbot を Slack で使用するための App 作成手順。
+xangi を Slack で使用するための App 作成手順。
 
 ## 1. Slack API にアクセス
 
@@ -12,18 +12,18 @@ Slack アカウントでログイン。
 
 1. **「Create New App」** をクリック
 2. **「From scratch」** を選択
-3. App Name: `kbot`（任意の名前）
+3. App Name: `xangi`（任意の名前）
 4. ワークスペースを選択
 5. **「Create App」** をクリック
 
 ## 3. Socket Mode を有効化（重要）
 
-kbot は Socket Mode で動作します（Webhook 不要）。
+xangi は Socket Mode で動作します（Webhook 不要）。
 
 1. 左メニュー **「Socket Mode」** をクリック
 2. **「Enable Socket Mode」** を ON
 3. App-Level Token を作成：
-   - Token Name: `kbot-socket`
+   - Token Name: `xangi-socket`
    - Scopes: `connections:write`
    - **「Generate」** をクリック
 4. 表示された **App Token（xapp-...）をコピー**
@@ -79,13 +79,7 @@ kbot は Socket Mode で動作します（Webhook 不要）。
 3. 権限を確認して **「許可する」**
 4. 表示された **Bot User OAuth Token（xoxb-...）をコピー**
 
-## 8. Signing Secret を取得
-
-1. 左メニュー **「Basic Information」** をクリック
-2. **「App Credentials」** セクション
-3. **「Signing Secret」** の **「Show」** をクリックしてコピー
-
-## 9. 環境変数を設定
+## 8. 環境変数を設定
 
 ```bash
 # .env を編集
@@ -99,14 +93,11 @@ SLACK_BOT_TOKEN=xoxb-your-bot-token
 # Slack App Token（xapp-...）Socket Mode 用
 SLACK_APP_TOKEN=xapp-your-app-token
 
-# Slack Signing Secret
-SLACK_SIGNING_SECRET=your-signing-secret
-
 # 許可するユーザー ID（Slack の User ID）
 ALLOWED_USER=U01234567
 ```
 
-## 10. 動作確認
+## 9. 動作確認
 
 ```bash
 # ビルド
@@ -116,11 +107,11 @@ npm run build
 docker compose up -d --build
 
 # ログ確認
-docker logs -f kbot
+docker logs -f xangi
 ```
 
 Slack で以下を試す：
-- Bot をメンション: `@kbot こんにちは！`
+- Bot をメンション: `@xangi こんにちは！`
 - DM を送信
 - `/new` コマンド
 - `/skills` コマンド
@@ -140,7 +131,7 @@ Slack で以下を試す：
 
 1. Socket Mode が有効になっているか確認
 2. Event Subscriptions で `app_mention`, `message.im` が設定されているか確認
-3. Bot がチャンネルに招待されているか確認（`/invite @kbot`）
+3. Bot がチャンネルに招待されているか確認（`/invite @xangi`）
 4. `ALLOWED_USER` が Slack の User ID になっているか確認
 
 ### スラッシュコマンドが動かない
@@ -162,7 +153,7 @@ Slack で以下を試す：
 Bot をチャンネルで使うには、チャンネルに招待する必要があります：
 
 ```
-/invite @kbot
+/invite @xangi
 ```
 
 ## セキュリティ注意事項

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "scripts": {
     "build": "tsc",
     "dev": "tsx watch src/index.ts",
-    "start": "node dist/index.js",
+    "start": "node --env-file=.env dist/index.js",
     "test": "vitest run",
     "test:watch": "vitest",
     "lint": "eslint src/",

--- a/src/claude-code.ts
+++ b/src/claude-code.ts
@@ -2,6 +2,13 @@ import { spawn } from 'child_process';
 import { processManager } from './process-manager.js';
 import type { RunOptions, RunResult, StreamCallbacks } from './agent-runner.js';
 
+// チャットプラットフォーム連携用のシステムプロンプト
+const CHAT_SYSTEM_PROMPT = `あなたはチャットプラットフォーム（Discord/Slack）経由で会話しています。
+ファイルをチャットに送信する場合は、出力に MEDIA:/path/to/file の形式でファイルパスを含めてください。
+対応形式: png, jpg, jpeg, gif, webp, mp3, mp4, wav, flac, pdf, zip
+例: 画像を生成した場合 → MEDIA:/tmp/output.png
+ユーザーが添付したファイルは [添付ファイル] としてパスが渡されます。`;
+
 export interface ClaudeCodeOptions {
   model?: string;
   timeoutMs?: number;
@@ -51,6 +58,9 @@ export class ClaudeCodeRunner {
     if (this.model) {
       args.push('--model', this.model);
     }
+
+    // チャットプラットフォーム連携のシステムプロンプト
+    args.push('--append-system-prompt', CHAT_SYSTEM_PROMPT);
 
     args.push(prompt);
 
@@ -153,6 +163,9 @@ export class ClaudeCodeRunner {
     if (this.model) {
       args.push('--model', this.model);
     }
+
+    // チャットプラットフォーム連携のシステムプロンプト
+    args.push('--append-system-prompt', CHAT_SYSTEM_PROMPT);
 
     args.push(prompt);
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -20,7 +20,6 @@ export interface Config {
     enabled: boolean;
     botToken?: string;
     appToken?: string;
-    signingSecret?: string;
     allowedUsers?: string[];
     autoReplyChannels?: string[];
     replyInThread?: boolean;
@@ -78,7 +77,6 @@ export function loadConfig(): Config {
       enabled: !!slackBotToken && !!slackAppToken,
       botToken: slackBotToken,
       appToken: slackAppToken,
-      signingSecret: process.env.SLACK_SIGNING_SECRET,
       allowedUsers: slackAllowedUsers,
       autoReplyChannels:
         process.env.SLACK_AUTO_REPLY_CHANNELS?.split(',')

--- a/src/file-utils.ts
+++ b/src/file-utils.ts
@@ -1,0 +1,84 @@
+import fs from 'fs';
+import path from 'path';
+import os from 'os';
+
+const DOWNLOAD_DIR = path.join(os.tmpdir(), 'xangi-attachments');
+
+// ダウンロードディレクトリを作成
+if (!fs.existsSync(DOWNLOAD_DIR)) {
+  fs.mkdirSync(DOWNLOAD_DIR, { recursive: true });
+}
+
+/**
+ * URLからファイルをダウンロードして一時ファイルに保存
+ */
+export async function downloadFile(
+  url: string,
+  filename: string,
+  authHeader?: Record<string, string>
+): Promise<string> {
+  const sanitized = filename.replace(/[^a-zA-Z0-9._-]/g, '_');
+  const filePath = path.join(DOWNLOAD_DIR, `${Date.now()}_${sanitized}`);
+
+  const headers: Record<string, string> = { ...authHeader };
+  const response = await fetch(url, { headers });
+
+  if (!response.ok) {
+    throw new Error(`Failed to download file: ${response.status} ${response.statusText}`);
+  }
+
+  const buffer = Buffer.from(await response.arrayBuffer());
+  fs.writeFileSync(filePath, buffer);
+  console.log(`[xangi] Downloaded attachment: ${filename} → ${filePath} (${buffer.length} bytes)`);
+  return filePath;
+}
+
+/**
+ * Agent結果からファイルパスを抽出
+ * パターン: MEDIA:/path/to/file または [ファイル](/path/to/file)
+ */
+export function extractFilePaths(text: string): string[] {
+  const paths: string[] = [];
+
+  // MEDIA:/path/to/file パターン
+  const mediaPattern = /MEDIA:\s*([^\s\n]+)/g;
+  let match;
+  while ((match = mediaPattern.exec(text)) !== null) {
+    const p = match[1].trim();
+    if (fs.existsSync(p)) {
+      paths.push(p);
+    }
+  }
+
+  // 絶対パスパターン（画像/音声/動画の拡張子を持つもの）
+  const absPathPattern =
+    /(?:^|\s)(\/[^\s]+\.(?:png|jpg|jpeg|gif|webp|mp3|mp4|wav|flac|pdf|zip))/gim;
+  while ((match = absPathPattern.exec(text)) !== null) {
+    const p = match[1].trim();
+    if (fs.existsSync(p) && !paths.includes(p)) {
+      paths.push(p);
+    }
+  }
+
+  return paths;
+}
+
+/**
+ * テキストからファイルパス部分を除去して表示用テキストを返す
+ */
+export function stripFilePaths(text: string): string {
+  return text
+    .replace(/MEDIA:\s*[^\s\n]+/g, '')
+    .replace(/\n{3,}/g, '\n\n')
+    .trim();
+}
+
+/**
+ * 添付ファイル情報をプロンプトに追加
+ */
+export function buildPromptWithAttachments(prompt: string, filePaths: string[]): string {
+  if (filePaths.length === 0) return prompt;
+
+  const fileList = filePaths.map((p) => `  - ${p}`).join('\n');
+  return `${prompt}\n\n[添付ファイル]\n${fileList}`;
+}

--- a/src/slack.ts
+++ b/src/slack.ts
@@ -5,12 +5,175 @@ import type { AgentRunner } from './agent-runner.js';
 import { processManager } from './process-manager.js';
 import type { Skill } from './skills.js';
 import { formatSkillList } from './skills.js';
+import {
+  downloadFile,
+  extractFilePaths,
+  stripFilePaths,
+  buildPromptWithAttachments,
+} from './file-utils.js';
 
 // ストリーミング更新の間隔（ミリ秒）
 const STREAM_UPDATE_INTERVAL_MS = 1000;
 
 // セッション管理（チャンネルID → セッションID）
 const sessions = new Map<string, string>();
+
+// 最後のBotメッセージ（チャンネルID → メッセージts）
+const lastBotMessages = new Map<string, string>();
+
+// Slack メッセージバイト数制限（chat.updateはバイト数で制限される）
+const SLACK_MAX_TEXT_BYTES = 3900;
+
+/**
+ * 文字列をUTF-8バイト数で安全に切り詰める
+ * マルチバイト文字の途中で切れないように処理
+ */
+function sliceByBytes(str: string, maxBytes: number): string {
+  const encoder = new TextEncoder();
+  if (encoder.encode(str).length <= maxBytes) {
+    return str;
+  }
+  // バイナリサーチで最大文字位置を見つける
+  let lo = 0;
+  let hi = str.length;
+  while (lo < hi) {
+    const mid = Math.ceil((lo + hi) / 2);
+    if (encoder.encode(str.slice(0, mid)).length <= maxBytes) {
+      lo = mid;
+    } else {
+      hi = mid - 1;
+    }
+  }
+  return str.slice(0, lo);
+}
+
+// 結果送信（長い場合は分割）
+async function sendSlackResult(
+  client: WebClient,
+  channelId: string,
+  messageTs: string,
+  threadTs: string | undefined,
+  result: string
+): Promise<void> {
+  const text = sliceByBytes(result, SLACK_MAX_TEXT_BYTES);
+  const textBytes = new TextEncoder().encode(text).length;
+  console.log(
+    `[slack] sendSlackResult: textChars=${text.length}, textBytes=${textBytes}, resultChars=${result.length}`
+  );
+
+  try {
+    await client.chat.update({
+      channel: channelId,
+      ts: messageTs,
+      text,
+    });
+
+    // 残りのテキストがあれば分割送信
+    if (text.length < result.length) {
+      const remaining = result.slice(text.length);
+      const chunks = splitTextByBytes(remaining, SLACK_MAX_TEXT_BYTES);
+      console.log(
+        `[slack] Sending remaining ${chunks.length} chunks (${remaining.length} chars left)`
+      );
+      for (const chunk of chunks) {
+        await client.chat.postMessage({
+          channel: channelId,
+          text: chunk,
+          ...(threadTs && { thread_ts: threadTs }),
+        });
+      }
+    }
+  } catch (err: unknown) {
+    const errorMessage = err instanceof Error ? err.message : String(err);
+    console.error('[slack] Failed to update final message:', errorMessage);
+
+    if (errorMessage.includes('msg_too_long')) {
+      console.log(`[slack] Fallback: trying shorter text (2000 bytes)`);
+      // テキストを短くしてリトライ
+      try {
+        await client.chat.update({
+          channel: channelId,
+          ts: messageTs,
+          text: sliceByBytes(result, 2000),
+        });
+        console.log(`[slack] Fallback: short update succeeded`);
+      } catch {
+        console.log(`[slack] Fallback: short update failed, using placeholder`);
+        // それでもダメなら新規メッセージとして投稿
+        await client.chat
+          .update({
+            channel: channelId,
+            ts: messageTs,
+            text: '（長文のため別メッセージで送信）',
+          })
+          .catch(() => {});
+      }
+
+      // 残りを分割送信
+      const chunks = splitTextByBytes(result, SLACK_MAX_TEXT_BYTES);
+      console.log(`[slack] Fallback: sending ${chunks.length} chunks`);
+      for (const chunk of chunks) {
+        await client.chat.postMessage({
+          channel: channelId,
+          text: chunk,
+          ...(threadTs && { thread_ts: threadTs }),
+        });
+      }
+      console.log(`[slack] Fallback: all chunks sent`);
+    } else {
+      // その他のエラーは再throw
+      throw err;
+    }
+  }
+}
+
+// テキストをバイト数で分割
+function splitTextByBytes(text: string, maxBytes: number): string[] {
+  const chunks: string[] = [];
+  let remaining = text;
+  while (remaining.length > 0) {
+    const chunk = sliceByBytes(remaining, maxBytes);
+    chunks.push(chunk);
+    remaining = remaining.slice(chunk.length);
+  }
+  return chunks;
+}
+
+// メッセージ削除の共通関数
+async function deleteMessage(client: WebClient, channelId: string, arg: string): Promise<string> {
+  let messageTs: string | undefined;
+
+  if (arg) {
+    // 引数がある場合: ts または メッセージリンクから抽出
+    const linkMatch = arg.match(/\/p(\d{10})(\d{6})/);
+    if (linkMatch) {
+      messageTs = `${linkMatch[1]}.${linkMatch[2]}`;
+    } else if (/^\d+\.\d+$/.test(arg)) {
+      messageTs = arg;
+    } else {
+      return '無効な形式です。メッセージリンクまたは ts を指定してください';
+    }
+  } else {
+    messageTs = lastBotMessages.get(channelId);
+    if (!messageTs) {
+      return '削除できるメッセージがありません';
+    }
+  }
+
+  try {
+    await client.chat.delete({
+      channel: channelId,
+      ts: messageTs,
+    });
+    if (!arg) {
+      lastBotMessages.delete(channelId);
+    }
+    return '🗑️ メッセージを削除しました';
+  } catch (err) {
+    console.error('[slack] Failed to delete message:', err);
+    return 'メッセージの削除に失敗しました';
+  }
+}
 
 export interface SlackChannelOptions {
   config: Config;
@@ -45,8 +208,30 @@ export async function startSlackBot(options: SlackChannelOptions): Promise<void>
       return;
     }
 
-    const text = (event.text || '').replace(/<@[A-Z0-9]+>/g, '').trim();
-    if (!text) return;
+    let text = (event.text || '').replace(/<@[A-Z0-9]+>/g, '').trim();
+
+    // 添付ファイルをダウンロード
+    const attachmentPaths: string[] = [];
+    const files = (event as unknown as Record<string, unknown>).files as
+      | Array<{ url_private_download?: string; name?: string }>
+      | undefined;
+    if (files && files.length > 0) {
+      for (const file of files) {
+        if (file.url_private_download) {
+          try {
+            const filePath = await downloadFile(file.url_private_download, file.name || 'file', {
+              Authorization: `Bearer ${config.slack.botToken}`,
+            });
+            attachmentPaths.push(filePath);
+          } catch (err) {
+            console.error(`[slack] Failed to download attachment: ${file.name}`, err);
+          }
+        }
+      }
+    }
+
+    if (!text && attachmentPaths.length === 0) return;
+    text = buildPromptWithAttachments(text || '添付ファイルを確認してください', attachmentPaths);
 
     const channelId = event.channel;
     const threadTs = config.slack.replyInThread ? event.thread_ts || event.ts : undefined;
@@ -71,6 +256,17 @@ export async function startSlackBot(options: SlackChannelOptions): Promise<void>
       return;
     }
 
+    // 削除コマンド
+    if (text === '!delete' || text === 'delete' || text.startsWith('!delete ')) {
+      const arg = text.replace(/^!?delete\s*/, '').trim();
+      const result = await deleteMessage(client, channelId, arg);
+      await say({
+        text: result,
+        ...(threadTs && { thread_ts: threadTs }),
+      });
+      return;
+    }
+
     // 👀 リアクション追加
     await client.reactions
       .add({
@@ -82,7 +278,7 @@ export async function startSlackBot(options: SlackChannelOptions): Promise<void>
         console.error('[slack] Failed to add reaction:', err.message || err);
       });
 
-    await processMessage(channelId, threadTs, text, client, agentRunner, config);
+    await processMessage(channelId, threadTs, text, event.ts, client, agentRunner, config);
   });
 
   // DMの処理 + autoReplyChannels
@@ -96,6 +292,7 @@ export async function startSlackBot(options: SlackChannelOptions): Promise<void>
       channel: string;
       ts: string;
       channel_type?: string;
+      files?: Array<{ url_private_download?: string; name?: string }>;
     };
 
     console.log(
@@ -110,14 +307,40 @@ export async function startSlackBot(options: SlackChannelOptions): Promise<void>
       return;
     }
 
+    // autoReplyChannels でメンション付きメッセージは app_mention で処理済みなのでスキップ
+    const textRaw = messageEvent.text || '';
+    if (isAutoReplyChannel && /<@[A-Z0-9]+>/i.test(textRaw)) {
+      console.log(`[slack] Skipping mention in autoReplyChannel (handled by app_mention)`);
+      return;
+    }
+
     // 許可リストチェック
     if (!config.slack.allowedUsers?.includes(messageEvent.user)) {
       console.log(`[slack] Unauthorized user: ${messageEvent.user}`);
       return;
     }
 
-    const text = messageEvent.text || '';
-    if (!text) return;
+    let text = messageEvent.text || '';
+
+    // 添付ファイルをダウンロード
+    const dmAttachmentPaths: string[] = [];
+    if (messageEvent.files && messageEvent.files.length > 0) {
+      for (const file of messageEvent.files) {
+        if (file.url_private_download) {
+          try {
+            const filePath = await downloadFile(file.url_private_download, file.name || 'file', {
+              Authorization: `Bearer ${config.slack.botToken}`,
+            });
+            dmAttachmentPaths.push(filePath);
+          } catch (err) {
+            console.error(`[slack] Failed to download attachment: ${file.name}`, err);
+          }
+        }
+      }
+    }
+
+    if (!text && dmAttachmentPaths.length === 0) return;
+    text = buildPromptWithAttachments(text || '添付ファイルを確認してください', dmAttachmentPaths);
 
     const channelId = messageEvent.channel;
     const threadTs = config.slack.replyInThread ? messageEvent.ts : undefined;
@@ -142,6 +365,17 @@ export async function startSlackBot(options: SlackChannelOptions): Promise<void>
       return;
     }
 
+    // 削除コマンド
+    if (text === '!delete' || text === 'delete' || text.startsWith('!delete ')) {
+      const arg = text.replace(/^!?delete\s*/, '').trim();
+      const result = await deleteMessage(client, channelId, arg);
+      await say({
+        text: result,
+        ...(threadTs && { thread_ts: threadTs }),
+      });
+      return;
+    }
+
     // 👀 リアクション追加
     await client.reactions
       .add({
@@ -153,7 +387,7 @@ export async function startSlackBot(options: SlackChannelOptions): Promise<void>
         console.error('[slack] Failed to add reaction:', err.message || err);
       });
 
-    await processMessage(channelId, threadTs, text, client, agentRunner, config);
+    await processMessage(channelId, threadTs, text, messageEvent.ts, client, agentRunner, config);
   });
 
   // /new コマンド
@@ -180,6 +414,21 @@ export async function startSlackBot(options: SlackChannelOptions): Promise<void>
 
     skills = reloadSkills();
     await respond({ text: formatSkillList(skills) });
+  });
+
+  // /delete コマンド（Botメッセージを削除）
+  // /delete → 直前のメッセージ
+  // /delete <ts> → 指定のメッセージ（tsまたはメッセージリンクから抽出）
+  app.command('/delete', async ({ command, ack, respond, client }) => {
+    await ack();
+
+    if (!config.slack.allowedUsers?.includes(command.user_id)) {
+      await respond({ text: '許可されていないユーザーです', response_type: 'ephemeral' });
+      return;
+    }
+
+    const result = await deleteMessage(client, command.channel_id, command.text.trim());
+    await respond({ text: result, response_type: 'ephemeral' });
   });
 
   // /skill コマンド
@@ -213,7 +462,7 @@ export async function startSlackBot(options: SlackChannelOptions): Promise<void>
       });
 
       sessions.set(channelId, newSessionId);
-      await respond({ text: result.slice(0, 3000) });
+      await respond({ text: sliceByBytes(result, SLACK_MAX_TEXT_BYTES) });
     } catch (error) {
       console.error('[slack] Error:', error);
       await respond({ text: 'エラーが発生しました' });
@@ -228,6 +477,7 @@ async function processMessage(
   channelId: string,
   threadTs: string | undefined,
   text: string,
+  originalTs: string,
   client: WebClient,
   agentRunner: AgentRunner,
   config: Config
@@ -261,6 +511,9 @@ async function processMessage(
       throw new Error('Failed to get message timestamp');
     }
 
+    // 最後のBotメッセージを保存
+    lastBotMessages.set(channelId, messageTs);
+
     let result: string;
     let newSessionId: string;
 
@@ -277,14 +530,22 @@ async function processMessage(
             if (now - lastUpdateTime >= STREAM_UPDATE_INTERVAL_MS && !pendingUpdate) {
               pendingUpdate = true;
               lastUpdateTime = now;
+              const streamText = sliceByBytes(fullText, SLACK_MAX_TEXT_BYTES - 10) + ' ▌';
+              const streamBytes = new TextEncoder().encode(streamText).length;
+              console.log(
+                `[slack] stream update: chars=${streamText.length}, bytes=${streamBytes}`
+              );
               client.chat
                 .update({
                   channel: channelId,
                   ts: messageTs,
-                  text: fullText.slice(0, 3000) + ' ▌',
+                  text: streamText,
                 })
                 .catch((err) => {
-                  console.error('[slack] Failed to update message:', err.message);
+                  console.error(
+                    `[slack] Failed to update message (bytes=${streamBytes}):`,
+                    err.message
+                  );
                 })
                 .finally(() => {
                   pendingUpdate = false;
@@ -324,12 +585,34 @@ async function processMessage(
     sessions.set(channelId, newSessionId);
     console.log(`[slack] Final result length: ${result.length}`);
 
-    // 最終結果を更新
-    await client.chat.update({
-      channel: channelId,
-      ts: messageTs,
-      text: result.slice(0, 3000),
-    });
+    // ファイルパスを抽出して添付送信
+    const filePaths = extractFilePaths(result);
+    const displayText = filePaths.length > 0 ? stripFilePaths(result) : result;
+
+    // 最終結果を更新（長い場合は分割送信）
+    await sendSlackResult(client, channelId, messageTs, threadTs, displayText || '✅');
+
+    if (filePaths.length > 0) {
+      try {
+        for (const fp of filePaths) {
+          const fileContent = await import('fs').then((fs) => fs.default.readFileSync(fp));
+          const filename = await import('path').then((path) => path.default.basename(fp));
+          const uploadArgs: Record<string, unknown> = {
+            channel_id: channelId,
+            file: fileContent,
+            filename,
+          };
+          if (threadTs) {
+            uploadArgs.thread_ts = threadTs;
+          }
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          await client.filesUploadV2(uploadArgs as any);
+        }
+        console.log(`[slack] Sent ${filePaths.length} file(s)`);
+      } catch (err) {
+        console.error('[slack] Failed to upload files:', err);
+      }
+    }
   } catch (error) {
     console.error('[slack] Error:', error);
     await client.chat.postMessage({
@@ -337,5 +620,16 @@ async function processMessage(
       text: 'エラーが発生しました',
       ...(threadTs && { thread_ts: threadTs }),
     });
+  } finally {
+    // 👀 リアクションを削除
+    await client.reactions
+      .remove({
+        channel: channelId,
+        timestamp: originalTs,
+        name: 'eyes',
+      })
+      .catch((err) => {
+        console.error('[slack] Failed to remove reaction:', err.message || err);
+      });
   }
 }


### PR DESCRIPTION
## xangi v0.2.0

### 新機能
- **ファイル添付対応**: Discord/Slackでファイルの受信・送信が可能に
- **Dockerfile.max**: uv + Python 3.12 入りのフルバージョンイメージ追加
- **Slack /delete コマンド**: メッセージ削除（指定ts・リンク対応）
- **Slack !delete コマンド**: メッセージコマンドでの削除
- **Slack 👀 リアクション削除**: 処理完了後にbotメッセージを自動削除
- **Agent システムプロンプト**: チャット連携情報（MEDIA:パターン等）をAgentに伝達

### バグ修正
- **Slack msg_too_long 修正**: バイト数ベースで切り詰め（日本語でも安定動作）
- **autoReplyChannels イベント重複防止**: メンション時のapp_mentionとmessageの同時発火を抑制
- **DISCORD_ALLOWED_USER 未設定時の警告修正**

### ドキュメント・設定
- kbot → xangi リネーム（ログ・ドキュメント）
- SLACK_SIGNING_SECRET 削除（Socket Modeでは不要）
- SLACK_REPLY_IN_THREAD オプション追加
- ローカル実行方法をREADMEに追加
- docker-compose.yml: xangi / xangi-max 切り替え対応
- GitHub CLI認証をホストのトークン方式に変更

### アップグレード方法
```bash
git pull
docker compose up xangi -d --build
```

フルバージョン（uv + Python）を使う場合:
```bash
docker compose up xangi-max -d --build
```