### PR TITLE
Release v0.9.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,6 +21,10 @@
     "src/**/*.ts": [
       "eslint --fix",
       "prettier --write"
+    ],
+    "{src,tests}/**/*.ts": [
+      "bash -c 'npx vitest run'",
+      "bash -c 'npx tsc --noEmit'"
     ]
   },
   "keywords": [

--- a/src/persistent-runner.ts
+++ b/src/persistent-runner.ts
@@ -79,8 +79,10 @@ export class PersistentRunner extends EventEmitter implements AgentRunner {
           `Circuit breaker open: ${this.crashCount} crashes in ${elapsed}ms. Waiting for cooldown.`
         );
       }
-      // クールダウン経過後はリセット
-      console.log('[persistent-runner] Circuit breaker reset after cooldown');
+      // クールダウン経過後はリセット（セッションは既にクリア済みなので新規セッションで起動）
+      console.log(
+        '[persistent-runner] Circuit breaker reset after cooldown. Starting fresh session.'
+      );
       this.crashCount = 0;
     }
 
@@ -161,10 +163,22 @@ export class PersistentRunner extends EventEmitter implements AgentRunner {
         console.log('[persistent-runner] Restarting process for queued requests...');
         this.processNext();
       } else if (this.crashCount >= PersistentRunner.MAX_CRASHES) {
-        // サーキットブレーカーオープン: キューを全部エラーにする
-        console.error('[persistent-runner] Circuit breaker OPEN. Rejecting all queued requests.');
+        // サーキットブレーカーオープン: セッションを破棄して次回は新規セッションで起動
+        console.error(
+          '[persistent-runner] Circuit breaker OPEN. Clearing session to recover on next request.'
+        );
+        const oldSessionId = this.sessionId || this.resumeSessionId;
+        this.sessionId = '';
+        this.resumeSessionId = undefined;
+        this.emit('session-invalidated', this.channelId, oldSessionId);
+
+        // キューを全部エラーにする
         for (const item of this.queue) {
-          item.reject(new Error('Circuit breaker open: too many process crashes'));
+          item.reject(
+            new Error(
+              'Circuit breaker open: too many process crashes. Session cleared for recovery.'
+            )
+          );
         }
         this.queue = [];
       }
@@ -244,6 +258,43 @@ export class PersistentRunner extends EventEmitter implements AgentRunner {
       }
 
       if (json.is_error) {
+        // --resume で起動して失敗した場合、セッションが古い可能性が高い
+        // セッションをクリアしてリトライする（1回だけ）
+        const resumeId = this.resumeSessionId;
+        if (resumeId) {
+          console.warn(
+            `[persistent-runner] Resume failed with session ${resumeId.slice(0, 8)}... Clearing stale session and retrying.`
+          );
+          const oldSessionId = resumeId;
+          this.resumeSessionId = undefined;
+          this.sessionId = '';
+          this.emit('session-invalidated', this.channelId, oldSessionId);
+
+          // プロセスをkillして新規セッションでリトライ
+          if (this.process) {
+            this.cancelling = true;
+            this.process.kill();
+            this.process = null;
+            this.processAlive = false;
+            this.buffer = '';
+          }
+
+          // 現在のリクエストをキューの先頭に戻してリトライ
+          if (this.currentItem) {
+            this.queue.unshift(this.currentItem);
+            this.currentItem = null;
+          }
+          this.fullText = '';
+
+          // cancelling フラグのクリアは close イベントで行われるが、
+          // プロセスがまだ死んでいない場合に備えて直接 processNext を呼ぶ
+          setTimeout(() => {
+            this.cancelling = false;
+            this.processNext();
+          }, 100);
+          return;
+        }
+
         const error = new Error(json.result || 'Unknown error');
         this.currentItem?.callbacks?.onError?.(error);
         this.currentItem?.reject(error);

--- a/src/runner-manager.ts
+++ b/src/runner-manager.ts
@@ -1,6 +1,7 @@
 import { PersistentRunner } from './persistent-runner.js';
 import type { AgentRunner, RunOptions, RunResult, StreamCallbacks } from './agent-runner.js';
 import type { AgentConfig } from './config.js';
+import { deleteSession } from './sessions.js';
 
 /**
  * プール内のランナー情報
@@ -64,6 +65,17 @@ export class RunnerManager implements AgentRunner {
 
     // 新しい PersistentRunner を作成
     const runner = new PersistentRunner({ ...this.agentConfig, channelId });
+
+    // セッション無効化イベント: sessions.json からも削除して永続的にリセット
+    runner.on('session-invalidated', (ch: string, oldSessionId: string) => {
+      if (ch) {
+        deleteSession(ch);
+        console.log(
+          `[runner-manager] Session invalidated for channel ${ch} (was: ${oldSessionId?.slice(0, 8) ?? 'none'}). Deleted from sessions.json.`
+        );
+      }
+    });
+
     this.pool.set(channelId, {
       runner,
       lastUsed: Date.now(),

--- a/tests/runner-manager.test.ts
+++ b/tests/runner-manager.test.ts
@@ -3,11 +3,15 @@ import { RunnerManager } from '../src/runner-manager.js';
 
 // PersistentRunner をモック
 vi.mock('../src/persistent-runner.js', () => {
-  class MockPersistentRunner {
+  const { EventEmitter } = require('events');
+
+  class MockPersistentRunner extends EventEmitter {
     private alive = true;
     private currentPrompt: string | null = null;
 
-    constructor() {}
+    constructor() {
+      super();
+    }
 
     async run(prompt: string) {
       this.currentPrompt = prompt;


### PR DESCRIPTION
## xangi v0.9.1

### バグ修正
- **壊れたセッションIDによるクラッシュループを自動復旧**: xangiアップデート後に古いセッションIDが `sessions.json` に残ると、`--resume` で毎回失敗してbotが応答不能になるバグを修正
  - `--resume` でエラー応答を受けた場合、セッションをクリアして新規セッションで自動リトライ（1回限り）
  - サーキットブレーカー発動時（3連続クラッシュ）にもセッションをクリアし、`sessions.json` から永続削除
  - `runner-manager` が `session-invalidated` イベントを受けて `sessions.json` を自動更新

### 開発体験の改善
- **pre-commitでテスト・型チェックを実行**: `lint-staged` に `vitest run` と `tsc --noEmit` を追加。CI失敗を事前防止
- **テストのMockPersistentRunnerにEventEmitter継承を追加**: `runner.on()` が正しく動作するように修正