### PR TITLE
Release v0.10.0

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -42,8 +42,26 @@ DISCORD_ALLOWED_USER=your_discord_user_id_here
 # ========================================
 # AIエージェント設定
 # ========================================
-# Agent backend: claude-code, codex, or gemini (default: claude-code)
+# Agent backend: claude-code, codex, gemini, or local-llm (default: claude-code)
 # AGENT_BACKEND=claude-code
+
+# ========================================
+# Local LLM設定（AGENT_BACKEND=local-llm の場合）
+# ========================================
+# LLMサーバーのURL（Ollama等、default: http://localhost:11434）
+# LOCAL_LLM_BASE_URL=http://localhost:11434
+
+# 使用するモデル名
+# LOCAL_LLM_MODEL=nemotron-3-nano
+
+# APIキー（vLLM等でAPIキーが必要な場合）
+# LOCAL_LLM_API_KEY=
+
+# Thinkingモデルの推論を有効にするか（default: true）
+# LOCAL_LLM_THINKING=true
+
+# 最大トークン数（default: 8192）
+# LOCAL_LLM_MAX_TOKENS=8192
 
 # Optional: Model to use (backend-specific)
 # AGENT_MODEL=

--- a/README.md
+++ b/README.md
@@ -2,11 +2,11 @@
 
 > **A**I **N**EON **G**ENESIS **I**NTELLIGENCE
 
-Claude Code / Codex / Gemini CLI をバックエンドに、Discord から利用できる AI アシスタント。
+Claude Code / Codex / Gemini CLI / Local LLM（Ollama等）をバックエンドに、Discord から利用できる AI アシスタント。
 
 ## Features
 
-- 🤖 マルチバックエンド対応（Claude Code / Codex / Gemini CLI）
+- 🤖 マルチバックエンド対応（Claude Code / Codex / Gemini CLI / Local LLM）
 - 💬 Discord 対応
 - 👤 シングルユーザー設計
 - 🐳 Docker対応（コンテナ隔離環境）
@@ -48,6 +48,7 @@ DISCORD_ALLOWED_USER=123456789012345678
 # Claude Code: curl -fsSL https://claude.ai/install.sh | bash
 # Codex CLI:   npm install -g @openai/codex
 # Gemini CLI:  npm install -g @google/gemini-cli
+# Local LLM:   Ollama (https://ollama.com) をインストール
 
 npm install
 npm run build
@@ -116,7 +117,11 @@ docker exec -it xangi claude
 
 | 変数 | 説明 | デフォルト |
 |------|------|-----------|
-| `AGENT_BACKEND` | エージェントバックエンド（`claude-code` / `codex` / `gemini`） | `claude-code` |
+| `AGENT_BACKEND` | エージェントバックエンド（`claude-code` / `codex` / `gemini` / `local-llm`） | `claude-code` |
+| `LOCAL_LLM_BASE_URL` | LLMサーバーURL（`local-llm`時） | `http://localhost:11434` |
+| `LOCAL_LLM_MODEL` | 使用モデル名（`local-llm`時） | - |
+| `LOCAL_LLM_THINKING` | Thinkingモデルの推論有効化（`local-llm`時） | `true` |
+| `LOCAL_LLM_MAX_TOKENS` | 最大トークン数（`local-llm`時） | `8192` |
 | `WORKSPACE_PATH` | 作業ディレクトリ（ホストのパス） | `./workspace` |
 | `AUTO_REPLY_CHANNELS` | メンションなしで応答するチャンネルID（カンマ区切り） | - |
 | `AGENT_MODEL` | 使用するモデル | - |

--- a/docs/design.md
+++ b/docs/design.md
@@ -4,7 +4,7 @@ xangiのアーキテクチャと設計思想について説明します。
 
 ## 概要
 
-xangiは「AI CLI（Claude Code / Codex CLI / Gemini CLI）をチャットプラットフォームから使えるようにするラッパー」です。
+xangiは「AI CLI（Claude Code / Codex CLI / Gemini CLI）やローカルLLM（Ollama等）をチャットプラットフォームから使えるようにするラッパー」です。
 
 ```
 User → Chat (Discord/Slack) → xangi → AI CLI → Workspace
@@ -20,7 +20,7 @@ User → Chat (Discord/Slack) → xangi → AI CLI → Workspace
 |----------|------|------|
 | Chat | ユーザーインターフェース | Discord.js, Slack Bolt |
 | xangi | AI CLIの統合・制御 | index.ts, agent-runner.ts |
-| AI CLI | 実際のAI処理 | Claude Code, Codex CLI, Gemini CLI |
+| AI CLI | 実際のAI処理 | Claude Code, Codex CLI, Gemini CLI, Local LLM |
 | Workspace | ファイル・スキル | skills/, AGENTS.md |
 
 ## コンポーネント
@@ -60,6 +60,7 @@ AGENTS.md / CHARACTER.md / USER.md 等のワークスペース設定は、各AI 
 | Claude Code | `CLAUDE.md` | `--append-system-prompt`（一回限り） |
 | Codex CLI | `AGENTS.md` | `<system-context>` タグで埋め込み |
 | Gemini CLI | `GEMINI.md` | CLI側で自動読み込み（xangi側の注入なし） |
+| Local LLM | `AGENTS.md`, `MEMORY.md` | システムプロンプトに直接埋め込み（`CLAUDE.md` は通常 `AGENTS.md` のシンボリックリンクのため除外） |
 
 ### AI CLIアダプター
 
@@ -69,6 +70,7 @@ AGENTS.md / CHARACTER.md / USER.md 等のワークスペース設定は、各AI 
 | persistent-runner.ts | Claude Code（常駐） | `--input-format=stream-json` で常駐プロセス化、キュー管理、サーキットブレーカー |
 | codex-cli.ts | Codex CLI | OpenAI製、0.98.0対応、cancel対応 |
 | gemini-cli.ts | Gemini CLI | Google製、セッション管理、ストリーミング対応 |
+| local-llm/runner.ts | Local LLM | Ollama等のローカルLLMを直接呼び出し、ツール実行・ストリーミング対応 |
 
 ### スケジューラー（scheduler.ts）
 
@@ -176,7 +178,7 @@ AI CLIの実装詳細を隠蔽し、交換可能に：
 
 ```typescript
 // 設定でバックエンドを切り替え
-AGENT_BACKEND=claude-code  # or codex or gemini
+AGENT_BACKEND=claude-code  # or codex or gemini or local-llm
 ```
 
 将来的に新しいAI CLIが登場しても、アダプターを追加するだけで対応可能。
@@ -238,6 +240,12 @@ src/
 ├── persistent-runner.ts # Claude Codeアダプター（常駐プロセス）
 ├── codex-cli.ts        # Codex CLIアダプター
 ├── gemini-cli.ts       # Gemini CLIアダプター
+├── local-llm/          # Local LLMアダプター
+│   ├── runner.ts       #   メインランナー（セッション管理・ツール実行ループ）
+│   ├── llm-client.ts   #   LLM APIクライアント（Ollama native + OpenAI互換）
+│   ├── context.ts      #   ワークスペースコンテキスト読み込み
+│   ├── tools.ts        #   ビルトインツール（exec/read/web_fetch）
+│   └── types.ts        #   型定義
 ├── scheduler.ts        # スケジューラー
 ├── schedule-cli.ts     # スケジューラーCLI
 ├── skills.ts           # スキルローダー
@@ -309,7 +317,7 @@ prompts/
 
 | 変数 | 説明 | デフォルト |
 |------|------|-----------|
-| `AGENT_BACKEND` | AI CLI（`claude-code` / `codex` / `gemini`） | `claude-code` |
+| `AGENT_BACKEND` | AI CLI（`claude-code` / `codex` / `gemini` / `local-llm`） | `claude-code` |
 | `AGENT_MODEL` | 使用するモデル | - |
 | `WORKSPACE_PATH` | 作業ディレクトリ（ホストのパス） | - |
 | `SKIP_PERMISSIONS` | デフォルトで許可スキップ | `false` |
@@ -318,6 +326,26 @@ prompts/
 | `MAX_PROCESSES` | 同時実行プロセス数の上限 | `10` |
 | `IDLE_TIMEOUT_MS` | アイドルプロセスの自動終了時間（ミリ秒） | `1800000`（30分） |
 | `DATA_DIR` | データ保存ディレクトリ | `/workspace/.xangi` |
+
+### Local LLM（`AGENT_BACKEND=local-llm` 時）
+
+| 変数 | 説明 | デフォルト |
+|------|------|-----------|
+| `LOCAL_LLM_BASE_URL` | LLMサーバーURL（Ollama等） | `http://localhost:11434` |
+| `LOCAL_LLM_MODEL` | 使用するモデル名 | - |
+| `LOCAL_LLM_API_KEY` | APIキー（vLLM等で必要な場合） | - |
+| `LOCAL_LLM_THINKING` | Thinkingモデルの推論を有効にするか | `true` |
+| `LOCAL_LLM_MAX_TOKENS` | 最大トークン数 | `8192` |
+
+**対応モデル例（Ollama）:**
+- `nemotron-3-nano` — NVIDIA Nemotron 3 Nano（24GB）軽量・高速
+- `nemotron-3-super` — NVIDIA Nemotron 3 Super（86GB）高精度・エージェント向け
+- `qwen3.5:9b` — Qwen 3.5 9B（9GB）Thinking対応
+- その他Ollamaで利用可能なモデル
+
+**API対応:**
+- Ollama native API（`/api/chat`）— `think:false` 対応、ストリーミング
+- OpenAI互換API（`/v1/chat/completions`）— vLLM等にも対応
 
 ### GitHub CLI
 

--- a/src/agent-runner.ts
+++ b/src/agent-runner.ts
@@ -2,6 +2,7 @@ import type { AgentBackend, AgentConfig } from './config.js';
 import { ClaudeCodeRunner } from './claude-code.js';
 import { CodexRunner } from './codex-cli.js';
 import { GeminiRunner } from './gemini-cli.js';
+import { LocalLlmRunner } from './local-llm/runner.js';
 import { RunnerManager } from './runner-manager.js';
 
 export interface RunOptions {
@@ -52,6 +53,8 @@ export function createAgentRunner(backend: AgentBackend, config: AgentConfig): A
       return new CodexRunner(config);
     case 'gemini':
       return new GeminiRunner(config);
+    case 'local-llm':
+      return new LocalLlmRunner(config);
     default:
       throw new Error(`Unknown agent backend: ${backend}`);
   }
@@ -97,6 +100,8 @@ export function getBackendDisplayName(backend: AgentBackend): string {
       return 'Codex';
     case 'gemini':
       return 'Gemini';
+    case 'local-llm':
+      return 'Local LLM';
     default:
       return backend;
   }

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,6 +1,6 @@
 import { DEFAULT_TIMEOUT_MS } from './constants.js';
 
-export type AgentBackend = 'claude-code' | 'codex' | 'gemini';
+export type AgentBackend = 'claude-code' | 'codex' | 'gemini' | 'local-llm';
 
 export interface AgentConfig {
   model?: string;
@@ -64,9 +64,14 @@ export function loadConfig(): Config {
   const slackAllowedUsers = slackAllowedUser ? [slackAllowedUser] : [];
 
   const backend = (process.env.AGENT_BACKEND || 'claude-code') as AgentBackend;
-  if (backend !== 'claude-code' && backend !== 'codex' && backend !== 'gemini') {
+  if (
+    backend !== 'claude-code' &&
+    backend !== 'codex' &&
+    backend !== 'gemini' &&
+    backend !== 'local-llm'
+  ) {
     throw new Error(
-      `Invalid AGENT_BACKEND: ${backend}. Must be 'claude-code', 'codex', or 'gemini'`
+      `Invalid AGENT_BACKEND: ${backend}. Must be 'claude-code', 'codex', 'gemini', or 'local-llm'`
     );
   }
 

--- a/src/local-llm/context.ts
+++ b/src/local-llm/context.ts
@@ -1,0 +1,28 @@
+/**
+ * ワークスペースコンテキスト（AGENTS.md, MEMORY.md）の読み込み
+ */
+import { readFileSync, existsSync } from 'fs';
+import { join } from 'path';
+
+// CLAUDE.md is typically a symlink to AGENTS.md, so only read AGENTS.md to avoid duplication
+const CONTEXT_FILES = ['AGENTS.md', 'MEMORY.md'];
+
+export function loadWorkspaceContext(workspace: string): string {
+  const parts: string[] = [];
+
+  for (const file of CONTEXT_FILES) {
+    const filePath = join(workspace, file);
+    if (existsSync(filePath)) {
+      try {
+        const content = readFileSync(filePath, 'utf-8');
+        if (content.trim()) {
+          parts.push(`## ${file}\n${content}`);
+        }
+      } catch {
+        // ignore read errors
+      }
+    }
+  }
+
+  return parts.join('\n\n');
+}

--- a/src/local-llm/llm-client.ts
+++ b/src/local-llm/llm-client.ts
@@ -1,0 +1,378 @@
+/**
+ * OpenAI互換 + Ollama ネイティブAPI 対応 LLMクライアント
+ */
+import type { LLMMessage, LLMToolCall, LLMChatOptions, LLMChatResponse } from './types.js';
+
+interface OpenAIMessage {
+  role: string;
+  content: string | null;
+  tool_calls?: Array<{
+    id: string;
+    type: 'function';
+    function: { name: string; arguments: string };
+  }>;
+  tool_call_id?: string;
+}
+
+interface OpenAIChatResponse {
+  choices: Array<{
+    message: {
+      role: string;
+      content: string | null;
+      reasoning?: string | null;
+      tool_calls?: Array<{
+        id: string;
+        type: 'function';
+        function: { name: string; arguments: string };
+      }>;
+    };
+    finish_reason: string;
+  }>;
+}
+
+function toOpenAIMessages(messages: LLMMessage[]): OpenAIMessage[] {
+  return messages.map((msg) => {
+    const m: OpenAIMessage = { role: msg.role, content: msg.content };
+    if (msg.toolCalls && msg.toolCalls.length > 0) {
+      m.tool_calls = msg.toolCalls.map((tc) => ({
+        id: tc.id,
+        type: 'function' as const,
+        function: { name: tc.name, arguments: JSON.stringify(tc.arguments) },
+      }));
+      m.content = null;
+    }
+    if (msg.toolCallId) {
+      m.tool_call_id = msg.toolCallId;
+    }
+    return m;
+  });
+}
+
+export class LLMClient {
+  constructor(
+    private readonly baseUrl: string,
+    private readonly model: string,
+    private readonly apiKey: string = '',
+    private readonly thinking: boolean = true,
+    private readonly defaultMaxTokens: number = 8192
+  ) {}
+
+  async chat(messages: LLMMessage[], options?: LLMChatOptions): Promise<LLMChatResponse> {
+    if (!this.thinking && this.isOllamaUrl()) {
+      return this.chatOllamaNative(messages, options);
+    }
+    return this.chatOpenAI(messages, options);
+  }
+
+  private isOllamaUrl(): boolean {
+    return this.baseUrl.includes('11434') || this.baseUrl.includes('ollama');
+  }
+
+  private async chatOllamaNative(
+    messages: LLMMessage[],
+    options?: LLMChatOptions
+  ): Promise<LLMChatResponse> {
+    const ollamaMessages = messages.map((msg) => ({
+      role: msg.role,
+      content: msg.content,
+    }));
+
+    if (options?.systemPrompt) {
+      ollamaMessages.unshift({ role: 'system', content: options.systemPrompt });
+    }
+
+    const body: Record<string, unknown> = {
+      model: this.model,
+      messages: ollamaMessages,
+      stream: false,
+      think: false,
+    };
+
+    if (options?.tools && options.tools.length > 0) {
+      body.tools = options.tools.map((t) => ({
+        type: 'function',
+        function: { name: t.name, description: t.description, parameters: t.parameters },
+      }));
+    }
+
+    body.options = {
+      num_predict: options?.maxTokens ?? this.defaultMaxTokens,
+      ...(options?.temperature !== undefined && { temperature: options.temperature }),
+    };
+
+    const response = await fetch(`${this.baseUrl}/api/chat`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(body),
+    });
+
+    if (!response.ok) {
+      throw new Error(`Ollama API error ${response.status}: ${await response.text()}`);
+    }
+
+    const data = (await response.json()) as {
+      message: {
+        role: string;
+        content: string;
+        tool_calls?: Array<{
+          function: { name: string; arguments: Record<string, unknown> };
+        }>;
+      };
+      done_reason?: string;
+    };
+
+    const toolCalls: LLMToolCall[] = [];
+    if (data.message.tool_calls) {
+      for (const tc of data.message.tool_calls) {
+        toolCalls.push({
+          id: crypto.randomUUID(),
+          name: tc.function.name,
+          arguments: tc.function.arguments ?? {},
+        });
+      }
+    }
+
+    let finishReason: LLMChatResponse['finishReason'] = 'stop';
+    if (toolCalls.length > 0) finishReason = 'tool_calls';
+    else if (data.done_reason === 'length') finishReason = 'length';
+
+    return {
+      content: data.message.content ?? '',
+      toolCalls: toolCalls.length > 0 ? toolCalls : undefined,
+      finishReason,
+    };
+  }
+
+  private async chatOpenAI(
+    messages: LLMMessage[],
+    options?: LLMChatOptions
+  ): Promise<LLMChatResponse> {
+    const requestMessages = toOpenAIMessages(messages);
+
+    if (options?.systemPrompt) {
+      requestMessages.unshift({ role: 'system', content: options.systemPrompt });
+    }
+
+    const body: Record<string, unknown> = {
+      model: this.model,
+      messages: requestMessages,
+      stream: false,
+      max_tokens: options?.maxTokens ?? this.defaultMaxTokens,
+    };
+
+    if (options?.tools && options.tools.length > 0) {
+      body.tools = options.tools.map((t) => ({
+        type: 'function',
+        function: { name: t.name, description: t.description, parameters: t.parameters },
+      }));
+    }
+
+    if (options?.temperature !== undefined) {
+      body.temperature = options.temperature;
+    }
+
+    const headers: Record<string, string> = { 'Content-Type': 'application/json' };
+    if (this.apiKey) headers['Authorization'] = `Bearer ${this.apiKey}`;
+
+    const response = await fetch(`${this.baseUrl}/v1/chat/completions`, {
+      method: 'POST',
+      headers,
+      body: JSON.stringify(body),
+    });
+
+    if (!response.ok) {
+      throw new Error(`LLM API error ${response.status}: ${await response.text()}`);
+    }
+
+    const data = (await response.json()) as OpenAIChatResponse;
+    const choice = data.choices[0];
+    if (!choice) throw new Error('No choices in LLM response');
+
+    const toolCalls: LLMToolCall[] = [];
+    if (choice.message.tool_calls) {
+      for (const tc of choice.message.tool_calls) {
+        let args: Record<string, unknown> = {};
+        try {
+          args = JSON.parse(tc.function.arguments) as Record<string, unknown>;
+        } catch {
+          args = { raw: tc.function.arguments };
+        }
+        toolCalls.push({
+          id: tc.id || crypto.randomUUID(),
+          name: tc.function.name,
+          arguments: args,
+        });
+      }
+    }
+
+    let finishReason: LLMChatResponse['finishReason'] = 'stop';
+    if (choice.finish_reason === 'tool_calls') finishReason = 'tool_calls';
+    else if (choice.finish_reason === 'length') finishReason = 'length';
+
+    // Thinking model: content が空で reasoning に推論が入ることがある
+    let content = choice.message.content ?? '';
+    if (!content && choice.message.reasoning) {
+      content = choice.message.reasoning;
+    }
+
+    return {
+      content,
+      toolCalls: toolCalls.length > 0 ? toolCalls : undefined,
+      finishReason,
+    };
+  }
+
+  async *chatStream(messages: LLMMessage[], options?: LLMChatOptions): AsyncGenerator<string> {
+    // Thinking model + Ollama → ネイティブAPIでストリーミング（think:false対応）
+    if (!this.thinking && this.isOllamaUrl()) {
+      yield* this.chatStreamOllamaNative(messages, options);
+      return;
+    }
+
+    const requestMessages = toOpenAIMessages(messages);
+
+    if (options?.systemPrompt) {
+      requestMessages.unshift({ role: 'system', content: options.systemPrompt });
+    }
+
+    const body: Record<string, unknown> = {
+      model: this.model,
+      messages: requestMessages,
+      stream: true,
+      max_tokens: options?.maxTokens ?? this.defaultMaxTokens,
+    };
+
+    if (options?.temperature !== undefined) body.temperature = options.temperature;
+
+    const headers: Record<string, string> = { 'Content-Type': 'application/json' };
+    if (this.apiKey) headers['Authorization'] = `Bearer ${this.apiKey}`;
+
+    const response = await fetch(`${this.baseUrl}/v1/chat/completions`, {
+      method: 'POST',
+      headers,
+      body: JSON.stringify(body),
+    });
+
+    if (!response.ok) {
+      throw new Error(`LLM API error ${response.status}: ${await response.text()}`);
+    }
+
+    if (!response.body) throw new Error('No response body for streaming');
+
+    const reader = response.body.getReader();
+    const decoder = new TextDecoder();
+    let buffer = '';
+    let hasContent = false;
+
+    try {
+      while (true) {
+        const { done, value } = await reader.read();
+        if (done) break;
+
+        buffer += decoder.decode(value, { stream: true });
+        const lines = buffer.split('\n');
+        buffer = lines.pop() ?? '';
+
+        for (const line of lines) {
+          const trimmed = line.trim();
+          if (!trimmed || trimmed === 'data: [DONE]') continue;
+          if (trimmed.startsWith('data: ')) {
+            try {
+              const chunk = JSON.parse(trimmed.slice(6)) as {
+                choices: Array<{ delta: { content?: string; reasoning?: string } }>;
+              };
+              const delta = chunk.choices[0]?.delta;
+              if (delta?.content) {
+                hasContent = true;
+                yield delta.content;
+              }
+            } catch {
+              // skip malformed chunks
+            }
+          }
+        }
+      }
+    } finally {
+      reader.releaseLock();
+    }
+
+    // Thinking model でcontentが空だった場合、non-streamingにフォールバック
+    if (!hasContent) {
+      const result = await this.chat(messages, options);
+      if (result.content) yield result.content;
+    }
+  }
+
+  /**
+   * Ollama ネイティブ API (/api/chat) でストリーミング（think:false対応）
+   */
+  private async *chatStreamOllamaNative(
+    messages: LLMMessage[],
+    options?: LLMChatOptions
+  ): AsyncGenerator<string> {
+    const ollamaMessages = messages.map((msg) => ({
+      role: msg.role,
+      content: msg.content,
+    }));
+
+    if (options?.systemPrompt) {
+      ollamaMessages.unshift({ role: 'system', content: options.systemPrompt });
+    }
+
+    const body: Record<string, unknown> = {
+      model: this.model,
+      messages: ollamaMessages,
+      stream: true,
+      think: false,
+    };
+
+    body.options = {
+      num_predict: options?.maxTokens ?? this.defaultMaxTokens,
+      ...(options?.temperature !== undefined && { temperature: options.temperature }),
+    };
+
+    const response = await fetch(`${this.baseUrl}/api/chat`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(body),
+    });
+
+    if (!response.ok) {
+      throw new Error(`Ollama API error ${response.status}: ${await response.text()}`);
+    }
+
+    if (!response.body) throw new Error('No response body for streaming');
+
+    const reader = response.body.getReader();
+    const decoder = new TextDecoder();
+    let buffer = '';
+
+    try {
+      while (true) {
+        const { done, value } = await reader.read();
+        if (done) break;
+
+        buffer += decoder.decode(value, { stream: true });
+        const lines = buffer.split('\n');
+        buffer = lines.pop() ?? '';
+
+        for (const line of lines) {
+          if (!line.trim()) continue;
+          try {
+            const chunk = JSON.parse(line) as {
+              message?: { content?: string };
+              done?: boolean;
+            };
+            if (chunk.message?.content) {
+              yield chunk.message.content;
+            }
+          } catch {
+            // skip malformed chunks
+          }
+        }
+      }
+    } finally {
+      reader.releaseLock();
+    }
+  }
+}

--- a/src/local-llm/runner.ts
+++ b/src/local-llm/runner.ts
@@ -1,0 +1,196 @@
+/**
+ * ローカルLLMバックエンド — xangi本体に統合
+ *
+ * Ollama等のOpenAI互換APIを直接叩いてエージェントループを実行する。
+ * 外部HTTPサーバー不要。
+ */
+import type { AgentRunner, RunOptions, RunResult, StreamCallbacks } from '../agent-runner.js';
+import type { AgentConfig } from '../config.js';
+import type { LLMMessage } from './types.js';
+import { LLMClient } from './llm-client.js';
+import { loadWorkspaceContext } from './context.js';
+import { getBuiltinTools, toLLMTools, executeTool } from './tools.js';
+import { loadSkills } from '../skills.js';
+
+const MAX_TOOL_ROUNDS = 10;
+const MAX_SESSION_MESSAGES = 50;
+
+/** セッション（会話履歴） */
+interface Session {
+  messages: LLMMessage[];
+  updatedAt: number;
+}
+
+export class LocalLlmRunner implements AgentRunner {
+  private readonly llm: LLMClient;
+  private readonly workdir: string;
+  private readonly sessions = new Map<string, Session>();
+  private readonly sessionTtlMs = 60 * 60 * 1000; // 1時間
+
+  constructor(config: AgentConfig) {
+    const baseUrl = (process.env.LOCAL_LLM_BASE_URL || 'http://localhost:11434').replace(/\/$/, '');
+    const model = process.env.LOCAL_LLM_MODEL || config.model || '';
+    const apiKey = process.env.LOCAL_LLM_API_KEY || '';
+    const thinking = process.env.LOCAL_LLM_THINKING !== 'false';
+    const maxTokens = process.env.LOCAL_LLM_MAX_TOKENS
+      ? parseInt(process.env.LOCAL_LLM_MAX_TOKENS, 10)
+      : 8192;
+
+    this.llm = new LLMClient(baseUrl, model, apiKey, thinking, maxTokens);
+    this.workdir = config.workdir || process.cwd();
+
+    console.log(`[local-llm] LLM: ${baseUrl} (model: ${model}, thinking: ${thinking})`);
+  }
+
+  async run(prompt: string, options?: RunOptions): Promise<RunResult> {
+    const sessionId = options?.sessionId || crypto.randomUUID();
+    this.cleanupSessions();
+
+    const session = this.getOrCreateSession(sessionId);
+    const systemPrompt = this.buildSystemPrompt();
+    const tools = getBuiltinTools();
+    const llmTools = toLLMTools(tools);
+
+    // ユーザーメッセージ追加
+    const userMsg: LLMMessage = { role: 'user', content: prompt };
+    session.messages.push(userMsg);
+
+    let toolRounds = 0;
+    let finalContent = '';
+
+    while (toolRounds <= MAX_TOOL_ROUNDS) {
+      const response = await this.llm.chat(session.messages, {
+        systemPrompt,
+        tools: llmTools.length > 0 ? llmTools : undefined,
+      });
+
+      if (
+        response.finishReason === 'stop' ||
+        !response.toolCalls ||
+        response.toolCalls.length === 0
+      ) {
+        finalContent = response.content;
+        session.messages.push({ role: 'assistant', content: response.content });
+        break;
+      }
+
+      // ツール呼び出し
+      session.messages.push({
+        role: 'assistant',
+        content: response.content ?? '',
+        toolCalls: response.toolCalls,
+      });
+
+      const toolContext = { workspace: this.workdir, channelId: options?.channelId };
+
+      for (const toolCall of response.toolCalls) {
+        const result = await executeTool(toolCall.name, toolCall.arguments, toolContext);
+        const toolResultContent = result.success
+          ? result.output
+          : `Error: ${result.error ?? 'Unknown error'}${result.output ? `\nOutput: ${result.output}` : ''}`;
+
+        session.messages.push({
+          role: 'tool',
+          content: toolResultContent,
+          toolCallId: toolCall.id,
+        });
+      }
+
+      toolRounds++;
+      if (toolRounds >= MAX_TOOL_ROUNDS) {
+        finalContent = 'Maximum tool rounds reached.';
+        break;
+      }
+    }
+
+    this.trimSession(session);
+    session.updatedAt = Date.now();
+
+    return { result: finalContent, sessionId };
+  }
+
+  async runStream(
+    prompt: string,
+    callbacks: StreamCallbacks,
+    options?: RunOptions
+  ): Promise<RunResult> {
+    const sessionId = options?.sessionId || crypto.randomUUID();
+    this.cleanupSessions();
+
+    const session = this.getOrCreateSession(sessionId);
+    const systemPrompt = this.buildSystemPrompt();
+
+    session.messages.push({ role: 'user', content: prompt });
+
+    try {
+      let fullText = '';
+      for await (const chunk of this.llm.chatStream(session.messages, { systemPrompt })) {
+        fullText += chunk;
+        callbacks.onText?.(chunk, fullText);
+      }
+
+      session.messages.push({ role: 'assistant', content: fullText });
+      this.trimSession(session);
+      session.updatedAt = Date.now();
+
+      const result: RunResult = { result: fullText, sessionId };
+      callbacks.onComplete?.(result);
+      return result;
+    } catch (err) {
+      const error = err instanceof Error ? err : new Error(String(err));
+      callbacks.onError?.(error);
+      throw error;
+    }
+  }
+
+  cancel(): boolean {
+    return true;
+  }
+
+  destroy(channelId: string): boolean {
+    // channelId をセッションIDとして使ってるなら削除
+    this.sessions.delete(channelId);
+    return true;
+  }
+
+  private buildSystemPrompt(): string {
+    const parts: string[] = [];
+
+    // ワークスペースコンテキスト（CLAUDE.md, AGENTS.md, MEMORY.md）
+    const context = loadWorkspaceContext(this.workdir);
+    if (context) parts.push(context);
+
+    // スキル一覧
+    const skills = loadSkills(this.workdir);
+    if (skills.length > 0) {
+      const skillList = skills.map((s) => `- ${s.name}: ${s.description}`).join('\n');
+      parts.push(`## Available Skills\n${skillList}`);
+    }
+
+    return parts.join('\n\n');
+  }
+
+  private getOrCreateSession(sessionId: string): Session {
+    let session = this.sessions.get(sessionId);
+    if (!session) {
+      session = { messages: [], updatedAt: Date.now() };
+      this.sessions.set(sessionId, session);
+    }
+    return session;
+  }
+
+  private trimSession(session: Session): void {
+    if (session.messages.length > MAX_SESSION_MESSAGES) {
+      session.messages = session.messages.slice(-MAX_SESSION_MESSAGES);
+    }
+  }
+
+  private cleanupSessions(): void {
+    const now = Date.now();
+    for (const [id, session] of this.sessions.entries()) {
+      if (now - session.updatedAt > this.sessionTtlMs) {
+        this.sessions.delete(id);
+      }
+    }
+  }
+}

--- a/src/local-llm/tools.ts
+++ b/src/local-llm/tools.ts
@@ -1,0 +1,200 @@
+/**
+ * ローカルLLM用ビルトインツール（exec, read, web_fetch）
+ */
+import { readFileSync, existsSync, statSync } from 'fs';
+import { resolve, join } from 'path';
+import { promisify } from 'util';
+import type { LLMTool, ToolContext, ToolResult, ToolHandler } from './types.js';
+
+// child_process を遅延ロード（テストのvi.mockとの衝突を避けるため）
+async function shellExec(
+  command: string,
+  options: { cwd?: string; timeout?: number; maxBuffer?: number }
+): Promise<{ stdout: string; stderr: string }> {
+  const cp = await import('child_process');
+  const execAsync = promisify(cp.exec);
+  return execAsync(command, options);
+}
+
+// --- exec tool ---
+
+const BLOCKED_PATTERNS = [
+  /\brm\s+-rf\s+\/\b/,
+  /\bmkfs\b/,
+  /\bdd\s+if=/,
+  /\bformat\s+[a-z]:/i,
+  />\s*\/dev\/[sh]d[a-z]/,
+  /\bsudo\s+rm\s+-rf/,
+  /:\(\)\s*\{.*\|\s*:\s*&\s*\}/, // fork bomb
+];
+
+const execToolHandler: ToolHandler = {
+  name: 'exec',
+  description: 'Execute a shell command and return its output.',
+  parameters: {
+    type: 'object',
+    properties: {
+      command: { type: 'string', description: 'The shell command to execute' },
+      cwd: { type: 'string', description: 'Working directory (optional)' },
+    },
+    required: ['command'],
+  },
+  async execute(args: Record<string, unknown>, context: ToolContext): Promise<ToolResult> {
+    const command = args.command as string;
+    const cwd = (args.cwd as string | undefined) ?? context.workspace;
+
+    if (!command || typeof command !== 'string') {
+      return { success: false, output: '', error: 'command must be a non-empty string' };
+    }
+    if (BLOCKED_PATTERNS.some((p) => p.test(command))) {
+      return { success: false, output: '', error: `Command blocked for safety: ${command}` };
+    }
+
+    try {
+      const { stdout, stderr } = await shellExec(command, {
+        cwd,
+        timeout: 30_000,
+        maxBuffer: 1024 * 1024,
+      });
+      return { success: true, output: [stdout, stderr].filter(Boolean).join('\n').trim() };
+    } catch (err) {
+      const e = err as { stdout?: string; stderr?: string; message?: string };
+      return {
+        success: false,
+        output: [e.stdout, e.stderr].filter(Boolean).join('\n').trim(),
+        error: e.message ?? String(err),
+      };
+    }
+  },
+};
+
+// --- read tool ---
+
+const readToolHandler: ToolHandler = {
+  name: 'read',
+  description: 'Read the contents of a file.',
+  parameters: {
+    type: 'object',
+    properties: {
+      path: { type: 'string', description: 'Path to the file (absolute or relative to workspace)' },
+    },
+    required: ['path'],
+  },
+  async execute(args: Record<string, unknown>, context: ToolContext): Promise<ToolResult> {
+    const filePath = args.path as string;
+    if (!filePath) return { success: false, output: '', error: 'path is required' };
+
+    const resolved = filePath.startsWith('/')
+      ? filePath
+      : resolve(join(context.workspace, filePath));
+    if (!existsSync(resolved))
+      return { success: false, output: '', error: `File not found: ${resolved}` };
+
+    const stat = statSync(resolved);
+    if (!stat.isFile()) return { success: false, output: '', error: `Not a file: ${resolved}` };
+    if (stat.size > 512 * 1024)
+      return { success: false, output: '', error: `File too large: ${stat.size} bytes` };
+
+    try {
+      return { success: true, output: readFileSync(resolved, 'utf-8') };
+    } catch (err) {
+      return { success: false, output: '', error: String(err) };
+    }
+  },
+};
+
+// --- web_fetch tool ---
+
+const webFetchToolHandler: ToolHandler = {
+  name: 'web_fetch',
+  description: 'Fetch the content of a URL.',
+  parameters: {
+    type: 'object',
+    properties: {
+      url: { type: 'string', description: 'The URL to fetch' },
+      method: {
+        type: 'string',
+        description: 'HTTP method (default: GET)',
+        enum: ['GET', 'POST', 'PUT', 'DELETE'],
+      },
+      body: { type: 'string', description: 'Request body for POST/PUT (JSON string)' },
+    },
+    required: ['url'],
+  },
+  async execute(args: Record<string, unknown>): Promise<ToolResult> {
+    const url = args.url as string;
+    const method = (args.method as string) ?? 'GET';
+    const body = args.body as string | undefined;
+
+    if (!url) return { success: false, output: '', error: 'url is required' };
+
+    try {
+      new URL(url);
+    } catch {
+      return { success: false, output: '', error: `Invalid URL: ${url}` };
+    }
+
+    const controller = new AbortController();
+    const timeoutId = setTimeout(() => controller.abort(), 15_000);
+
+    try {
+      const opts: RequestInit = {
+        method,
+        signal: controller.signal,
+        headers: {
+          'User-Agent': 'xangi/local-llm',
+          Accept: 'text/html,application/json,text/plain,*/*',
+        },
+      };
+      if (body && ['POST', 'PUT'].includes(method)) {
+        opts.body = body;
+        (opts.headers as Record<string, string>)['Content-Type'] = 'application/json';
+      }
+
+      const res = await fetch(url, opts);
+      let text = await res.text();
+      if (text.length > 100 * 1024) text = text.slice(0, 100 * 1024) + '\n... [truncated]';
+
+      if (!res.ok) return { success: false, output: text, error: `HTTP ${res.status}` };
+      return { success: true, output: text };
+    } catch (err) {
+      const e = err as Error;
+      if (e.name === 'AbortError')
+        return { success: false, output: '', error: 'Request timed out' };
+      return { success: false, output: '', error: String(err) };
+    } finally {
+      clearTimeout(timeoutId);
+    }
+  },
+};
+
+// --- Registry ---
+
+const ALL_TOOLS: ToolHandler[] = [execToolHandler, readToolHandler, webFetchToolHandler];
+
+export function getBuiltinTools(): ToolHandler[] {
+  return ALL_TOOLS;
+}
+
+export function toLLMTools(handlers: ToolHandler[]): LLMTool[] {
+  return handlers.map((h) => ({
+    name: h.name,
+    description: h.description,
+    parameters: h.parameters,
+  }));
+}
+
+export async function executeTool(
+  name: string,
+  args: Record<string, unknown>,
+  context: ToolContext
+): Promise<ToolResult> {
+  const handler = ALL_TOOLS.find((t) => t.name === name);
+  if (!handler) return { success: false, output: '', error: `Unknown tool: ${name}` };
+
+  try {
+    return await handler.execute(args, context);
+  } catch (err) {
+    return { success: false, output: '', error: `Tool error: ${String(err)}` };
+  }
+}

--- a/src/local-llm/types.ts
+++ b/src/local-llm/types.ts
@@ -1,0 +1,58 @@
+export interface LLMMessage {
+  role: 'system' | 'user' | 'assistant' | 'tool';
+  content: string;
+  toolCalls?: LLMToolCall[];
+  toolCallId?: string;
+}
+
+export interface LLMToolCall {
+  id: string;
+  name: string;
+  arguments: Record<string, unknown>;
+}
+
+export interface LLMTool {
+  name: string;
+  description: string;
+  parameters: {
+    type: 'object';
+    properties: Record<string, { type: string; description?: string; enum?: string[] }>;
+    required?: string[];
+  };
+}
+
+export interface LLMChatOptions {
+  tools?: LLMTool[];
+  temperature?: number;
+  maxTokens?: number;
+  systemPrompt?: string;
+}
+
+export interface LLMChatResponse {
+  content: string;
+  toolCalls?: LLMToolCall[];
+  finishReason: 'stop' | 'tool_calls' | 'length';
+}
+
+export interface ToolContext {
+  workspace: string;
+  userId?: string;
+  channelId?: string;
+}
+
+export interface ToolResult {
+  success: boolean;
+  output: string;
+  error?: string;
+}
+
+export interface ToolHandler {
+  name: string;
+  description: string;
+  parameters: {
+    type: 'object';
+    properties: Record<string, { type: string; description?: string; enum?: string[] }>;
+    required?: string[];
+  };
+  execute(args: Record<string, unknown>, context: ToolContext): Promise<ToolResult>;
+}


### PR DESCRIPTION
# Release v0.10.0

## New Features

### Local LLM バックエンド (`AGENT_BACKEND=local-llm`)
Ollama等のローカルLLMをxangiから直接利用可能に。別サーバー不要で、xangi内で完結。

- **Ollama native API + OpenAI互換API** の両対応（vLLM等でも利用可能）
- **Thinkingモデル対応** — `think:false` やトークン数調整で推論制御
- **ワークスペースコンテキスト自動読み込み** — AGENTS.md, MEMORY.md をシステムプロンプトに埋め込み
- **ビルトインツール** — exec / read / web_fetch でファイル操作やコマンド実行が可能
- **ストリーミング応答対応**

### 対応モデル例（Ollama）
- `nemotron-3-nano` — NVIDIA Nemotron 3 Nano（24GB）軽量・高速
- `nemotron-3-super` — NVIDIA Nemotron 3 Super（86GB）高精度・エージェント向け
- `qwen3.5:9b` — Qwen 3.5 9B（9GB）Thinking対応

### 環境変数
| 変数 | 説明 | デフォルト |
|------|------|-----------|
| `LOCAL_LLM_BASE_URL` | LLMサーバーURL | `http://localhost:11434` |
| `LOCAL_LLM_MODEL` | モデル名 | - |
| `LOCAL_LLM_API_KEY` | APIキー（vLLM等用） | - |
| `LOCAL_LLM_THINKING` | Thinking有効化 | `true` |
| `LOCAL_LLM_MAX_TOKENS` | 最大トークン数 | `8192` |

## Documentation
- README.md にLocal LLMバックエンドの説明を追加
- docs/design.md にアーキテクチャ・環境変数・対応モデル・ファイル構成を追加