### PR TITLE
Release v0.11.0

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -31,12 +31,14 @@ DISCORD_TOKEN=your_discord_bot_token_here
 # SLACK_REPLY_IN_THREAD=false
 
 # ========================================
-# 許可ユーザー設定（各プラットフォームで1人のみ）
+# 許可ユーザー設定
 # ========================================
-# Discord用
+# Discord用（カンマ区切りで複数指定可、"*" で全員許可）
 DISCORD_ALLOWED_USER=your_discord_user_id_here
+# 複数ユーザー例: DISCORD_ALLOWED_USER=123456789,987654321
+# 全員許可: DISCORD_ALLOWED_USER=*
 
-# Slack用
+# Slack用（カンマ区切りで複数指定可、"*" で全員許可）
 # SLACK_ALLOWED_USER=your_slack_user_id_here
 
 # ========================================
@@ -48,7 +50,9 @@ DISCORD_ALLOWED_USER=your_discord_user_id_here
 # ========================================
 # Local LLM設定（AGENT_BACKEND=local-llm の場合）
 # ========================================
-# LLMサーバーのURL（Ollama等、default: http://localhost:11434）
+# LLMサーバーのURL
+# ローカル実行: http://localhost:11434（デフォルト）
+# Docker実行: http://ollama-proxy:11434（デフォルト、プロキシ経由でホストのOllamaに接続）
 # LOCAL_LLM_BASE_URL=http://localhost:11434
 
 # 使用するモデル名
@@ -63,6 +67,10 @@ DISCORD_ALLOWED_USER=your_discord_user_id_here
 # 最大トークン数（default: 8192）
 # LOCAL_LLM_MAX_TOKENS=8192
 
+# コンテキストウィンドウサイズ（Ollama num_ctx、default: モデルのデフォルト値）
+# 小さいほど応答が速い。未指定だとモデルの最大値（例: 262144）が使われて遅くなる
+# LOCAL_LLM_NUM_CTX=64000
+
 # Optional: Model to use (backend-specific)
 # AGENT_MODEL=
 
@@ -71,6 +79,10 @@ DISCORD_ALLOWED_USER=your_discord_user_id_here
 
 # Optional: Workspace path for agent (default: ./workspace)
 # WORKSPACE_PATH=/path/to/your/workspace
+
+# Docker用: ホストのワークスペースパス（docker-compose.ymlのvolumeマウント用）
+# ホスト環境変数との衝突を避けるためWORKSPACE_PATHとは別名
+# XANGI_WORKSPACE=/path/to/your/workspace
 
 # Optional: Skip permissions by default (true/false, default: false)
 # SKIP_PERMISSIONS=false

--- a/README.md
+++ b/README.md
@@ -8,8 +8,9 @@ Claude Code / Codex / Gemini CLI / Local LLM（Ollama等）をバックエンド
 
 - 🤖 マルチバックエンド対応（Claude Code / Codex / Gemini CLI / Local LLM）
 - 💬 Discord 対応
-- 👤 シングルユーザー設計
+- 👤 マルチユーザー対応（複数ユーザー許可 / 全員許可）
 - 🐳 Docker対応（コンテナ隔離環境）
+- 🔒 環境変数ホワイトリスト（AIにシークレットを渡さない）
 - 📚 スキルシステム（スラッシュコマンド対応）
 - 🐙 GitHub CLI（gh）対応
 - ⏰ スケジューラー機能（cron / 単発 / 起動時タスク）
@@ -33,7 +34,7 @@ cp .env.example .env
 # Discord Bot Token（必須）
 DISCORD_TOKEN=your_discord_bot_token
 
-# 許可ユーザーID（必須）
+# 許可ユーザーID（必須、カンマ区切りで複数可、"*"で全員許可）
 DISCORD_ALLOWED_USER=123456789012345678
 ```
 
@@ -95,6 +96,8 @@ pm2 logs xangi     # ログ確認
 
 コンテナ隔離環境で実行したい場合は Docker も利用できます。
 
+### Claude Code バックエンド
+
 ```bash
 docker compose up xangi -d --build
 ```
@@ -104,6 +107,37 @@ Claude Code 認証:
 docker exec -it xangi claude
 ```
 
+### Local LLM バックエンド（Ollama）
+
+Ollamaコンテナが同梱されているため、ホストにOllamaをインストールする必要はありません。
+
+```bash
+# .env を設定
+AGENT_BACKEND=local-llm
+LOCAL_LLM_MODEL=nemotron-3-nano
+
+# 起動（ollama + xangi-max）
+docker compose up -d --build
+```
+
+> **⚠️ 注意**: ホストのシェルに `DISCORD_TOKEN` 等の環境変数が設定されていると `.env` を上書きします。`env -i` で環境変数をクリアして起動するか、`unset DISCORD_TOKEN` 等で対処してください。
+
+### Docker操作
+
+```bash
+# 停止
+docker compose down
+
+# 再起動（.env変更後など）
+docker compose up xangi-max -d --force-recreate
+
+# xangi-maxのみ再起動（ollamaはそのまま）
+docker compose up xangi-max -d
+
+# ログ確認
+docker logs -f xangi-max
+```
+
 ## 環境変数
 
 ### 必須
@@ -111,7 +145,7 @@ docker exec -it xangi claude
 | 変数 | 説明 |
 |------|------|
 | `DISCORD_TOKEN` | Discord Bot Token |
-| `DISCORD_ALLOWED_USER` | 許可ユーザーID |
+| `DISCORD_ALLOWED_USER` | 許可ユーザーID（カンマ区切りで複数可、`*`で全員許可） |
 
 ### オプション
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,41 +1,24 @@
 # 共通設定
 x-common: &common
   restart: unless-stopped
+  env_file:
+    - .env
   volumes:
     # Claude Code CLI 認証情報（コンテナ専用ボリューム）
     - claude-data:/home/node/.claude
     # Codex CLI 認証情報（コンテナ専用ボリューム）
     - codex-data:/home/node/.codex
     # ワークスペース（エージェントの作業ディレクトリ）
-    - ${WORKSPACE_PATH:-./workspace}:/workspace
+    - ${XANGI_WORKSPACE:-./workspace}:/workspace
     # Git設定
     - ~/.gitconfig:/home/node/.gitconfig:ro
   environment: &common-env
-    # GitHub CLI (GH_TOKEN環境変数で認証)
-    - GH_TOKEN=${GH_TOKEN:-}
+    # env_fileから読み込まれない固定値のみここに記述
     - NODE_ENV=production
-    # Discord
-    - DISCORD_TOKEN=${DISCORD_TOKEN:-}
-    - AUTO_REPLY_CHANNELS=${AUTO_REPLY_CHANNELS:-}
-    - DISCORD_STREAMING=${DISCORD_STREAMING:-true}
-    - DISCORD_SHOW_THINKING=${DISCORD_SHOW_THINKING:-true}
-    # Slack
-    - SLACK_BOT_TOKEN=${SLACK_BOT_TOKEN:-}
-    - SLACK_APP_TOKEN=${SLACK_APP_TOKEN:-}
-    - SLACK_AUTO_REPLY_CHANNELS=${SLACK_AUTO_REPLY_CHANNELS:-}
-    - SLACK_REPLY_IN_THREAD=${SLACK_REPLY_IN_THREAD:-true}
-    - SLACK_STREAMING=${SLACK_STREAMING:-true}
-    - SLACK_SHOW_THINKING=${SLACK_SHOW_THINKING:-true}
-    # Common
-    - DISCORD_ALLOWED_USER=${DISCORD_ALLOWED_USER:-}
-    - SLACK_ALLOWED_USER=${SLACK_ALLOWED_USER:-}
     - WORKSPACE_PATH=/workspace
-    - SKIP_PERMISSIONS=${SKIP_PERMISSIONS:-false}
-    # Agent
-    - AGENT_BACKEND=${AGENT_BACKEND:-claude-code}
-    - AGENT_MODEL=${AGENT_MODEL:-}
-    # Scheduler data directory (for schedules.json)
     - DATA_DIR=/workspace/.xangi
+    # ollamaコンテナへの接続（.envで未設定時のデフォルト）
+    - LOCAL_LLM_BASE_URL=${LOCAL_LLM_BASE_URL:-http://ollama:11434}
 
 services:
   # ミニマム版（デフォルト）
@@ -51,8 +34,21 @@ services:
       context: .
       dockerfile: Dockerfile.max
     container_name: xangi-max
-    ports:
-      - "8080:8080"
+
+  # Ollama（GPU付きコンテナ）
+  ollama:
+    image: ollama/ollama:latest
+    container_name: ollama
+    restart: unless-stopped
+    volumes:
+      - ${OLLAMA_MODELS_PATH:-/usr/share/ollama/.ollama}:/root/.ollama
+    deploy:
+      resources:
+        reservations:
+          devices:
+            - driver: nvidia
+              count: all
+              capabilities: [gpu]
 
 volumes:
   claude-data:

--- a/docs/design.md
+++ b/docs/design.md
@@ -135,15 +135,17 @@ skills/
    - !schedule → handleScheduleMessage()
    - /command → スラッシュコマンド処理
    ↓
-5. AI CLIに転送（processPrompt）
+5. チャンネル情報・発言者情報を付与
    ↓
-6. レスポンス処理
+6. AI CLIに転送（processPrompt）
+   ↓
+7. レスポンス処理
    - ストリーミング表示
    - ファイル添付抽出
    - SYSTEM_COMMAND検出
    - !discord / !schedule 検出・実行
    ↓
-7. ユーザーに返信
+8. ユーザーに返信
 ```
 
 ### スケジュール実行フロー
@@ -164,13 +166,14 @@ skills/
 
 ## 設計思想
 
-### シングルユーザー設計
+### ユーザー管理
 
-xangiは**1人のユーザー**が使う前提で設計されています：
+xangiのユーザー管理はシンプルな許可リスト方式：
 
-- 認証は `ALLOWED_USER` による単純なID照合
+- `DISCORD_ALLOWED_USER` / `SLACK_ALLOWED_USER` でアクセス制御
+- カンマ区切りで複数ユーザー指定可能、`*` で全員許可
 - セッションはチャンネル単位で管理
-- マルチテナント機能は意図的に省略
+- プロンプトに発言者情報（表示名・Discord ID）が自動注入される
 
 ### AI CLIの抽象化
 
@@ -267,25 +270,54 @@ prompts/
 
 ```
 ┌─────────────────────────────────────────┐
-│ xangi container                         │
+│ xangi-max container                     │
 ├─────────────────────────────────────────┤
 │ - Node.js 22                            │
 │ - Claude Code CLI / Codex CLI / Gemini  │
 │ - GitHub CLI (gh)                       │
-│ - (xangi-max) uv + Python 3.12          │
+│ - uv + Python                           │
+└───────────────┬─────────────────────────┘
+                │
+                ├── /workspace (bind mount)
+                ├── /home/node/.claude (volume)
+                ├── /home/node/.codex (volume)
+                └── /home/node/.config/gh (volume)
+
+┌─────────────────────────────────────────┐
+│ ollama container                        │
+├─────────────────────────────────────────┤
+│ - Ollama公式イメージ                     │
+│ - GPU パススルー                         │
+│ - ~/.ollama/models をvolumeマウント      │
+│ - xangi-maxから ollama:11434 で接続     │
 └─────────────────────────────────────────┘
-         │
-         ├── /workspace (bind mount)
-         ├── /home/node/.claude (volume)
-         ├── /home/node/.codex (volume)
-         └── /home/node/.config/gh (volume)
 ```
+
+**Docker環境でのLocal LLM利用:**
+- xangi-maxとollamaは同じdocker networkに接続
+- `.env` の `LOCAL_LLM_BASE_URL` はデフォルト（`http://ollama:11434`）でOK
+- Ollamaのモデルデータはvolumeで永続化
+- ホストのOllamaを使う場合は `ollama-proxy`（socat）経由も可能
 
 ### セキュリティ
 
 - 非rootユーザー（node）で実行
 - ワークスペースのみマウント
 - 認証情報はvolumeで永続化
+- AIエージェントへの環境変数はホワイトリスト方式で制限（`src/safe-env.ts`）
+- ホストネットワークへの直接アクセスなし（ollamaコンテナ経由のみ）
+- `extra_hosts` なし → ホストの他サービスにアクセス不可
+
+### 環境変数のホワイトリスト
+
+AIエージェント（CLI spawn / Local LLM exec）に渡す環境変数は `src/safe-env.ts` で管理。
+ホワイトリストに記載された変数のみ渡され、`DISCORD_TOKEN` 等のシークレットはAIからアクセス不可。
+
+**許可される変数:** `PATH`, `HOME`, `USER`, `SHELL`, `LANG`, `LC_*`, `TERM`, `TMPDIR`, `TZ`, `NODE_ENV`, `NODE_PATH`, `WORKSPACE_PATH`, `AGENT_BACKEND`, `AGENT_MODEL`, `SKIP_PERMISSIONS`, `DATA_DIR`
+
+**渡されない変数（例）:** `DISCORD_TOKEN`, `SLACK_BOT_TOKEN`, `SLACK_APP_TOKEN`, `LOCAL_LLM_API_KEY`, `GH_TOKEN`
+
+ホワイトリストを変更する場合は `src/safe-env.ts` の `ALLOWED_ENV_KEYS` を編集する。
 
 ## 環境変数一覧
 
@@ -294,7 +326,7 @@ prompts/
 | 変数 | 説明 | 必須 |
 |------|------|------|
 | `DISCORD_TOKEN` | Discord Bot Token | ✅ |
-| `DISCORD_ALLOWED_USER` | 許可ユーザーID（1人のみ） | ✅ |
+| `DISCORD_ALLOWED_USER` | 許可ユーザーID（カンマ区切りで複数可、`*`で全員許可） | ✅ |
 | `AUTO_REPLY_CHANNELS` | メンションなしで応答するチャンネルID（カンマ区切り） | - |
 | `DISCORD_STREAMING` | ストリーミング出力（デフォルト: `true`） | - |
 | `DISCORD_SHOW_THINKING` | 思考過程を表示（デフォルト: `true`） | - |

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -13,6 +13,7 @@ xangiの詳細な使い方ガイドです。
 - [コマンドプレフィックス](#コマンドプレフィックス)
 - [ランタイム設定](#ランタイム設定)
 - [AIによる自律操作](#aiによる自律操作)
+- [Local LLM（Ollama等）](#local-llmollama等)
 - [トラブルシューティング](#トラブルシューティング)
 
 ## 基本操作
@@ -276,6 +277,61 @@ pm2 restart xangi
 > **⚠️ `pm2 restart --update-env` は使わないこと！**
 > `--update-env` はシェルの全環境変数をpm2に保存します。複数のxangiインスタンスを動かしている場合、別インスタンスの `DISCORD_TOKEN` 等が混入し、同じbotトークンで二重ログインする原因になります。
 > `node --env-file=.env` は既存の環境変数を上書きしないため、pm2が先にセットした値が優先されてしまいます。
+
+## Local LLM（Ollama等）
+
+### ローカル実行
+
+```bash
+# .env を設定
+AGENT_BACKEND=local-llm
+LOCAL_LLM_MODEL=nemotron-3-nano
+# LOCAL_LLM_BASE_URL=http://localhost:11434  # デフォルト
+```
+
+Ollamaが起動していればそのまま動作します。
+
+### Docker実行
+
+Docker実行時は Ollama コンテナが同じ docker network 内で起動し、`ollama:11434` で接続します。
+
+```bash
+# .env を設定（LOCAL_LLM_BASE_URL は省略可、デフォルトで ollama:11434）
+AGENT_BACKEND=local-llm
+LOCAL_LLM_MODEL=nemotron-3-nano
+```
+
+```bash
+# 起動（ollama + xangi-max）
+docker compose up -d
+
+# xangi-maxのみ再起動（.env変更後など）
+docker compose up xangi-max -d --force-recreate
+```
+
+#### 注意事項
+
+- **ホスト環境変数に注意**: `docker compose` は `.env` よりホストのシェル環境変数を優先する。別のxangiインスタンスの `DISCORD_TOKEN` 等が設定されていると上書きされる。`unset DISCORD_TOKEN` してから起動すること
+- **xangiコンテナ単体の起動**: `docker compose up xangi-max -d` でxangi-maxだけ起動すると、ollamaが起動しない場合がある。初回は `docker compose up -d` で全サービス起動を推奨
+
+#### セキュリティ
+
+- xangiコンテナはホストネットワークに**直接アクセスできません**
+- Ollamaコンテナは同じdocker network内で隔離
+- AIエージェントがホストの他サービス（SSH、Web等）にアクセスすることを防止
+- AIエージェントへの環境変数はホワイトリスト方式で制限（`DISCORD_TOKEN` 等はアクセス不可）
+
+> **⚠️ `localhost:11434` はコンテナ自身を指すため使えません。Docker実行時はデフォルトのまま（`ollama:11434`）で動作します。**
+
+### 対応モデル例
+
+| モデル | サイズ | 特徴 |
+|--------|--------|------|
+| `nemotron-3-nano` | 24GB | 軽量・高速 |
+| `nemotron-3-super` | 86GB | 高精度・エージェント向け |
+| `qwen3.5:9b` | 9GB | Thinking対応 |
+
+その他Ollamaで利用可能なモデルに対応しています。
 
 ## トラブルシューティング
 

--- a/src/base-runner.ts
+++ b/src/base-runner.ts
@@ -76,3 +76,6 @@ export function buildSystemPrompt(): string {
 export function buildPersistentSystemPrompt(): string {
   return CHAT_SYSTEM_PROMPT_PERSISTENT + loadXangiCommands();
 }
+
+// safe-env.ts から再エクスポート（既存のimportを壊さないため）
+export { getSafeEnv } from './safe-env.js';

--- a/src/claude-code.ts
+++ b/src/claude-code.ts
@@ -3,6 +3,7 @@ import { processManager } from './process-manager.js';
 import type { RunOptions, RunResult, StreamCallbacks } from './agent-runner.js';
 import { mergeTexts, sanitizeSurrogates } from './agent-runner.js';
 import { DEFAULT_TIMEOUT_MS } from './constants.js';
+import { getSafeEnv } from './base-runner.js';
 import { buildSystemPrompt } from './base-runner.js';
 import { logPrompt, logResponse } from './transcript-logger.js';
 
@@ -96,6 +97,7 @@ export class ClaudeCodeRunner {
       const proc = spawn('claude', args, {
         stdio: ['ignore', 'pipe', 'pipe'],
         cwd: this.workdir,
+        env: getSafeEnv(),
       });
 
       // プロセスマネージャーに登録
@@ -200,6 +202,7 @@ export class ClaudeCodeRunner {
       const proc = spawn('claude', args, {
         stdio: ['ignore', 'pipe', 'pipe'],
         cwd: this.workdir,
+        env: getSafeEnv(),
       });
 
       // プロセスマネージャーに登録

--- a/src/codex-cli.ts
+++ b/src/codex-cli.ts
@@ -2,7 +2,7 @@ import { spawn, ChildProcess } from 'child_process';
 import { processManager } from './process-manager.js';
 import type { AgentRunner, RunOptions, RunResult, StreamCallbacks } from './agent-runner.js';
 import { DEFAULT_TIMEOUT_MS } from './constants.js';
-import { buildSystemPrompt } from './base-runner.js';
+import { buildSystemPrompt, getSafeEnv } from './base-runner.js';
 import { logPrompt, logResponse } from './transcript-logger.js';
 
 export interface CodexOptions {
@@ -157,6 +157,7 @@ export class CodexRunner implements AgentRunner {
       const proc = spawn('codex', args, {
         stdio: ['ignore', 'pipe', 'pipe'],
         cwd: this.workdir,
+        env: getSafeEnv(),
       });
       this.currentProcess = proc;
 
@@ -270,6 +271,7 @@ export class CodexRunner implements AgentRunner {
       const proc = spawn('codex', args, {
         stdio: ['ignore', 'pipe', 'pipe'],
         cwd: this.workdir,
+        env: getSafeEnv(),
       });
       this.currentProcess = proc;
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -60,8 +60,18 @@ export function loadConfig(): Config {
 
   const discordAllowedUser = process.env.DISCORD_ALLOWED_USER;
   const slackAllowedUser = process.env.SLACK_ALLOWED_USER;
-  const discordAllowedUsers = discordAllowedUser ? [discordAllowedUser] : [];
-  const slackAllowedUsers = slackAllowedUser ? [slackAllowedUser] : [];
+  const discordAllowedUsers = discordAllowedUser
+    ? discordAllowedUser
+        .split(',')
+        .map((s) => s.trim())
+        .filter(Boolean)
+    : [];
+  const slackAllowedUsers = slackAllowedUser
+    ? slackAllowedUser
+        .split(',')
+        .map((s) => s.trim())
+        .filter(Boolean)
+    : [];
 
   const backend = (process.env.AGENT_BACKEND || 'claude-code') as AgentBackend;
   if (

--- a/src/gemini-cli.ts
+++ b/src/gemini-cli.ts
@@ -2,6 +2,7 @@ import { spawn, ChildProcess } from 'child_process';
 import { processManager } from './process-manager.js';
 import type { AgentRunner, RunOptions, RunResult, StreamCallbacks } from './agent-runner.js';
 import { DEFAULT_TIMEOUT_MS } from './constants.js';
+import { getSafeEnv, buildSystemPrompt } from './base-runner.js';
 import type { BaseRunnerOptions } from './base-runner.js';
 import { logPrompt, logResponse } from './transcript-logger.js';
 
@@ -52,7 +53,6 @@ export class GeminiRunner implements AgentRunner {
     this.timeoutMs = options?.timeoutMs ?? DEFAULT_TIMEOUT_MS;
     this.workdir = options?.workdir;
     this.skipPermissions = options?.skipPermissions ?? false;
-    // Gemini CLIはGEMINI.mdを自動読み込みするため、xangi側でのシステムプロンプト注入は不要
   }
 
   /**
@@ -79,7 +79,8 @@ export class GeminiRunner implements AgentRunner {
   }
 
   async run(prompt: string, options?: RunOptions): Promise<RunResult> {
-    const fullPrompt = prompt;
+    const systemPrompt = buildSystemPrompt();
+    const fullPrompt = systemPrompt ? `${systemPrompt}\n\n---\n\n${prompt}` : prompt;
     const args = [
       ...this.buildBaseArgs(options),
       '--prompt',
@@ -153,6 +154,7 @@ export class GeminiRunner implements AgentRunner {
       const proc = spawn('gemini', args, {
         stdio: ['ignore', 'pipe', 'pipe'],
         cwd: this.workdir,
+        env: getSafeEnv(),
       });
       this.currentProcess = proc;
 
@@ -225,7 +227,8 @@ export class GeminiRunner implements AgentRunner {
     callbacks: StreamCallbacks,
     options?: RunOptions
   ): Promise<RunResult> {
-    const fullPrompt = prompt;
+    const systemPrompt = buildSystemPrompt();
+    const fullPrompt = systemPrompt ? `${systemPrompt}\n\n---\n\n${prompt}` : prompt;
     const args = [
       ...this.buildBaseArgs(options),
       '--prompt',
@@ -272,6 +275,7 @@ export class GeminiRunner implements AgentRunner {
       const proc = spawn('gemini', args, {
         stdio: ['ignore', 'pipe', 'pipe'],
         cwd: this.workdir,
+        env: getSafeEnv(),
       });
       this.currentProcess = proc;
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -96,22 +96,28 @@ const lastSentMessageIds = new Map<string, string>();
 async function main() {
   const config = loadConfig();
 
-  // 許可リストの必須チェック（各プラットフォームで1人のみ許可）
+  // 許可リストのチェック（"*" で全員許可、カンマ区切りで複数ユーザー対応）
   const discordAllowed = config.discord.allowedUsers || [];
   const slackAllowed = config.slack.allowedUsers || [];
 
   if (config.discord.enabled && discordAllowed.length === 0) {
-    console.error('[xangi] Error: ALLOWED_USER must be set for Discord');
+    console.error('[xangi] Error: DISCORD_ALLOWED_USER must be set (use "*" to allow everyone)');
     process.exit(1);
   }
   if (config.slack.enabled && slackAllowed.length === 0) {
-    console.error('[xangi] Error: SLACK_ALLOWED_USER or ALLOWED_USER must be set for Slack');
+    console.error('[xangi] Error: SLACK_ALLOWED_USER must be set (use "*" to allow everyone)');
     process.exit(1);
   }
-  if (discordAllowed.length > 1 || slackAllowed.length > 1) {
-    console.error('[xangi] Error: Only one user per platform is allowed');
-    console.error('[xangi] 利用規約遵守のため、複数ユーザーの設定は禁止です');
-    process.exit(1);
+
+  if (discordAllowed.includes('*')) {
+    console.log('[xangi] Discord: All users are allowed');
+  } else {
+    console.log(`[xangi] Discord: Allowed users: ${discordAllowed.join(', ')}`);
+  }
+  if (slackAllowed.includes('*')) {
+    console.log('[xangi] Slack: All users are allowed');
+  } else if (slackAllowed.length > 0) {
+    console.log(`[xangi] Slack: Allowed users: ${slackAllowed.join(', ')}`);
   }
 
   const client = new Client({
@@ -261,8 +267,11 @@ async function main() {
 
     if (!interaction.isChatInputCommand()) return;
 
-    // 許可リストチェック
-    if (!config.discord.allowedUsers?.includes(interaction.user.id)) {
+    // 許可リストチェック（"*" で全員許可）
+    if (
+      !config.discord.allowedUsers?.includes('*') &&
+      !config.discord.allowedUsers?.includes(interaction.user.id)
+    ) {
       await interaction.reply({ content: '許可されていないユーザーです', ephemeral: true });
       return;
     }
@@ -1126,7 +1135,10 @@ async function main() {
       return;
     }
 
-    if (!config.discord.allowedUsers?.includes(message.author.id)) {
+    if (
+      !config.discord.allowedUsers?.includes('*') &&
+      !config.discord.allowedUsers?.includes(message.author.id)
+    ) {
       console.log(`[xangi] Unauthorized user: ${message.author.id} (${message.author.tag})`);
       return;
     }
@@ -1315,14 +1327,16 @@ async function main() {
           agentPrompt = `[現在時刻: ${now}(${day})]\n${agentPrompt}`;
         }
 
-        const sessionId = getSession(channelId);
+        // スケジューラーは毎回新規セッション（stateless）
+        // 会話の文脈継続は不要で、古いセッションIDによるresume失敗を防ぐ
         const { result, sessionId: newSessionId } = await agentRunner.run(agentPrompt, {
           skipPermissions: config.agent.config.skipPermissions ?? false,
-          sessionId,
+          sessionId: undefined,
           channelId,
         });
 
-        setSession(channelId, newSessionId);
+        // スケジューラーのセッションは scheduler スコープで保存
+        setSession(channelId, newSessionId, 'scheduler');
 
         // AI応答内の !discord コマンドを処理（sourceMessage なし、channelIdをフォールバック）
         const feedbackResults = await handleDiscordCommandsInResponse(result, undefined, channelId);
@@ -1333,13 +1347,14 @@ async function main() {
           console.log(
             `[scheduler] Re-injecting ${feedbackResults.length} feedback result(s) to agent`
           );
+          // フィードバックは直前のスケジューラーセッションを使う（同一タスク内の文脈継続）
           const feedbackSession = getSession(channelId);
           const feedbackRun = await agentRunner.run(feedbackPrompt, {
             skipPermissions: config.agent.config.skipPermissions ?? false,
             sessionId: feedbackSession,
             channelId,
           });
-          setSession(channelId, feedbackRun.sessionId);
+          setSession(channelId, feedbackRun.sessionId, 'scheduler');
           // 再注入後の応答にもコマンドがあれば処理
           await handleDiscordCommandsInResponse(feedbackRun.result, undefined, channelId);
         }
@@ -1692,11 +1707,14 @@ async function processPrompt(
 ): Promise<string | null> {
   let replyMessage: Message | null = null;
   try {
-    // チャンネル情報をプロンプトに付与
+    // チャンネル・ユーザー情報をプロンプトに付与
     const channelName =
       'name' in message.channel ? (message.channel as { name: string }).name : null;
+    const userInfo = `[発言者: ${message.author.displayName ?? message.author.username} (ID: ${message.author.id})]`;
     if (channelName) {
-      prompt = `[チャンネル: #${channelName} (ID: ${channelId})]\n${prompt}`;
+      prompt = `[チャンネル: #${channelName} (ID: ${channelId})]\n${userInfo}\n${prompt}`;
+    } else {
+      prompt = `${userInfo}\n${prompt}`;
     }
 
     console.log(`[xangi] Processing message in channel ${channelId}`);

--- a/src/local-llm/llm-client.ts
+++ b/src/local-llm/llm-client.ts
@@ -49,13 +49,18 @@ function toOpenAIMessages(messages: LLMMessage[]): OpenAIMessage[] {
 }
 
 export class LLMClient {
+  private readonly timeoutMs: number;
+
   constructor(
     private readonly baseUrl: string,
     private readonly model: string,
     private readonly apiKey: string = '',
     private readonly thinking: boolean = true,
-    private readonly defaultMaxTokens: number = 8192
-  ) {}
+    private readonly defaultMaxTokens: number = 8192,
+    private readonly numCtx?: number
+  ) {
+    this.timeoutMs = parseInt(process.env.TIMEOUT_MS || '300000', 10);
+  }
 
   async chat(messages: LLMMessage[], options?: LLMChatOptions): Promise<LLMChatResponse> {
     if (!this.thinking && this.isOllamaUrl()) {
@@ -97,14 +102,26 @@ export class LLMClient {
 
     body.options = {
       num_predict: options?.maxTokens ?? this.defaultMaxTokens,
+      ...(this.numCtx && { num_ctx: this.numCtx }),
       ...(options?.temperature !== undefined && { temperature: options.temperature }),
     };
 
-    const response = await fetch(`${this.baseUrl}/api/chat`, {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify(body),
-    });
+    const controller = new AbortController();
+    const timeoutId = setTimeout(() => controller.abort(), this.timeoutMs);
+    if (options?.signal) {
+      options.signal.addEventListener('abort', () => controller.abort());
+    }
+    let response: Response;
+    try {
+      response = await fetch(`${this.baseUrl}/api/chat`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(body),
+        signal: controller.signal,
+      });
+    } finally {
+      clearTimeout(timeoutId);
+    }
 
     if (!response.ok) {
       throw new Error(`Ollama API error ${response.status}: ${await response.text()}`);
@@ -174,11 +191,23 @@ export class LLMClient {
     const headers: Record<string, string> = { 'Content-Type': 'application/json' };
     if (this.apiKey) headers['Authorization'] = `Bearer ${this.apiKey}`;
 
-    const response = await fetch(`${this.baseUrl}/v1/chat/completions`, {
-      method: 'POST',
-      headers,
-      body: JSON.stringify(body),
-    });
+    const controller = new AbortController();
+    const timeoutId = setTimeout(() => controller.abort(), this.timeoutMs);
+    // 外部からのAbortSignalも連携
+    if (options?.signal) {
+      options.signal.addEventListener('abort', () => controller.abort());
+    }
+    let response: Response;
+    try {
+      response = await fetch(`${this.baseUrl}/v1/chat/completions`, {
+        method: 'POST',
+        headers,
+        body: JSON.stringify(body),
+        signal: controller.signal,
+      });
+    } finally {
+      clearTimeout(timeoutId);
+    }
 
     if (!response.ok) {
       throw new Error(`LLM API error ${response.status}: ${await response.text()}`);
@@ -251,6 +280,7 @@ export class LLMClient {
       method: 'POST',
       headers,
       body: JSON.stringify(body),
+      signal: options?.signal,
     });
 
     if (!response.ok) {
@@ -328,6 +358,7 @@ export class LLMClient {
 
     body.options = {
       num_predict: options?.maxTokens ?? this.defaultMaxTokens,
+      ...(this.numCtx && { num_ctx: this.numCtx }),
       ...(options?.temperature !== undefined && { temperature: options.temperature }),
     };
 

--- a/src/local-llm/runner.ts
+++ b/src/local-llm/runner.ts
@@ -11,6 +11,7 @@ import { LLMClient } from './llm-client.js';
 import { loadWorkspaceContext } from './context.js';
 import { getBuiltinTools, toLLMTools, executeTool } from './tools.js';
 import { loadSkills } from '../skills.js';
+import { CHAT_SYSTEM_PROMPT_PERSISTENT, loadXangiCommands } from '../base-runner.js';
 
 const MAX_TOOL_ROUNDS = 10;
 const MAX_SESSION_MESSAGES = 50;
@@ -26,6 +27,7 @@ export class LocalLlmRunner implements AgentRunner {
   private readonly workdir: string;
   private readonly sessions = new Map<string, Session>();
   private readonly sessionTtlMs = 60 * 60 * 1000; // 1時間
+  private readonly activeAbortControllers = new Map<string, AbortController>();
 
   constructor(config: AgentConfig) {
     const baseUrl = (process.env.LOCAL_LLM_BASE_URL || 'http://localhost:11434').replace(/\/$/, '');
@@ -35,8 +37,11 @@ export class LocalLlmRunner implements AgentRunner {
     const maxTokens = process.env.LOCAL_LLM_MAX_TOKENS
       ? parseInt(process.env.LOCAL_LLM_MAX_TOKENS, 10)
       : 8192;
+    const numCtx = process.env.LOCAL_LLM_NUM_CTX
+      ? parseInt(process.env.LOCAL_LLM_NUM_CTX, 10)
+      : undefined;
 
-    this.llm = new LLMClient(baseUrl, model, apiKey, thinking, maxTokens);
+    this.llm = new LLMClient(baseUrl, model, apiKey, thinking, maxTokens, numCtx);
     this.workdir = config.workdir || process.cwd();
 
     console.log(`[local-llm] LLM: ${baseUrl} (model: ${model}, thinking: ${thinking})`);
@@ -84,11 +89,17 @@ export class LocalLlmRunner implements AgentRunner {
       const toolContext = { workspace: this.workdir, channelId: options?.channelId };
 
       for (const toolCall of response.toolCalls) {
+        console.log(
+          `[local-llm] Tool call: ${toolCall.name}(${JSON.stringify(toolCall.arguments).slice(0, 200)})`
+        );
         const result = await executeTool(toolCall.name, toolCall.arguments, toolContext);
         const toolResultContent = result.success
           ? result.output
           : `Error: ${result.error ?? 'Unknown error'}${result.output ? `\nOutput: ${result.output}` : ''}`;
 
+        console.log(
+          `[local-llm] Tool result: ${result.success ? 'OK' : 'FAIL'} (${toolResultContent.length} chars)`
+        );
         session.messages.push({
           role: 'tool',
           content: toolResultContent,
@@ -119,12 +130,63 @@ export class LocalLlmRunner implements AgentRunner {
 
     const session = this.getOrCreateSession(sessionId);
     const systemPrompt = this.buildSystemPrompt();
+    const tools = getBuiltinTools();
+    const llmTools = toLLMTools(tools);
 
     session.messages.push({ role: 'user', content: prompt });
 
+    const channelId = options?.channelId || sessionId;
+    const abortController = new AbortController();
+    this.activeAbortControllers.set(channelId, abortController);
+
     try {
+      // ツールループ: non-streaming の chat() でツール呼び出しを処理
+      let toolRounds = 0;
+      while (toolRounds < MAX_TOOL_ROUNDS) {
+        const response = await this.llm.chat(session.messages, {
+          systemPrompt,
+          tools: llmTools.length > 0 ? llmTools : undefined,
+          signal: abortController.signal,
+        });
+
+        if (!response.toolCalls || response.toolCalls.length === 0) {
+          break;
+        }
+
+        // ツール呼び出し処理
+        session.messages.push({
+          role: 'assistant',
+          content: response.content ?? '',
+          toolCalls: response.toolCalls,
+        });
+
+        const toolContext = { workspace: this.workdir, channelId: options?.channelId };
+        for (const toolCall of response.toolCalls) {
+          console.log(
+            `[local-llm] Tool call: ${toolCall.name}(${JSON.stringify(toolCall.arguments).slice(0, 200)})`
+          );
+          const result = await executeTool(toolCall.name, toolCall.arguments, toolContext);
+          const toolResultContent = result.success
+            ? result.output
+            : `Error: ${result.error ?? 'Unknown error'}${result.output ? `\nOutput: ${result.output}` : ''}`;
+          console.log(
+            `[local-llm] Tool result: ${result.success ? 'OK' : 'FAIL'} (${toolResultContent.length} chars)`
+          );
+          session.messages.push({
+            role: 'tool',
+            content: toolResultContent,
+            toolCallId: toolCall.id,
+          });
+        }
+        toolRounds++;
+      }
+
+      // 最終応答をストリーミングで取得
       let fullText = '';
-      for await (const chunk of this.llm.chatStream(session.messages, { systemPrompt })) {
+      for await (const chunk of this.llm.chatStream(session.messages, {
+        systemPrompt,
+        signal: abortController.signal,
+      })) {
         fullText += chunk;
         callbacks.onText?.(chunk, fullText);
       }
@@ -140,11 +202,29 @@ export class LocalLlmRunner implements AgentRunner {
       const error = err instanceof Error ? err : new Error(String(err));
       callbacks.onError?.(error);
       throw error;
+    } finally {
+      this.activeAbortControllers.delete(channelId);
     }
   }
 
-  cancel(): boolean {
-    return true;
+  cancel(channelId?: string): boolean {
+    if (channelId) {
+      const controller = this.activeAbortControllers.get(channelId);
+      if (controller) {
+        controller.abort();
+        this.activeAbortControllers.delete(channelId);
+        return true;
+      }
+    }
+    // channelId不明の場合は全部止める
+    if (this.activeAbortControllers.size > 0) {
+      for (const [id, controller] of this.activeAbortControllers) {
+        controller.abort();
+        this.activeAbortControllers.delete(id);
+      }
+      return true;
+    }
+    return false;
   }
 
   destroy(channelId: string): boolean {
@@ -156,15 +236,24 @@ export class LocalLlmRunner implements AgentRunner {
   private buildSystemPrompt(): string {
     const parts: string[] = [];
 
+    // チャットプラットフォーム説明 + xangiコマンド（base-runner共通）
+    parts.push(CHAT_SYSTEM_PROMPT_PERSISTENT + loadXangiCommands());
+
     // ワークスペースコンテキスト（CLAUDE.md, AGENTS.md, MEMORY.md）
     const context = loadWorkspaceContext(this.workdir);
     if (context) parts.push(context);
 
-    // スキル一覧
+    // スキル一覧と使い方
     const skills = loadSkills(this.workdir);
     if (skills.length > 0) {
       const skillList = skills.map((s) => `- ${s.name}: ${s.description}`).join('\n');
-      parts.push(`## Available Skills\n${skillList}`);
+      parts.push(
+        `## Available Skills\n${skillList}\n\n` +
+          `### How to use skills\n` +
+          `1. Use the \`read\` tool to read the skill's SKILL.md file (e.g. \`skills/<skill-name>/SKILL.md\`)\n` +
+          `2. Follow the instructions in SKILL.md to execute the skill using the \`exec\` tool\n` +
+          `3. When a user's request matches a skill's description, always use that skill instead of answering from memory`
+      );
     }
 
     return parts.join('\n\n');

--- a/src/local-llm/tools.ts
+++ b/src/local-llm/tools.ts
@@ -5,11 +5,12 @@ import { readFileSync, existsSync, statSync } from 'fs';
 import { resolve, join } from 'path';
 import { promisify } from 'util';
 import type { LLMTool, ToolContext, ToolResult, ToolHandler } from './types.js';
+import { getSafeEnv } from '../safe-env.js';
 
 // child_process を遅延ロード（テストのvi.mockとの衝突を避けるため）
 async function shellExec(
   command: string,
-  options: { cwd?: string; timeout?: number; maxBuffer?: number }
+  options: { cwd?: string; timeout?: number; maxBuffer?: number; env?: NodeJS.ProcessEnv }
 ): Promise<{ stdout: string; stderr: string }> {
   const cp = await import('child_process');
   const execAsync = promisify(cp.exec);
@@ -55,6 +56,7 @@ const execToolHandler: ToolHandler = {
         cwd,
         timeout: 30_000,
         maxBuffer: 1024 * 1024,
+        env: getSafeEnv(),
       });
       return { success: true, output: [stdout, stderr].filter(Boolean).join('\n').trim() };
     } catch (err) {
@@ -94,6 +96,14 @@ const readToolHandler: ToolHandler = {
     if (!stat.isFile()) return { success: false, output: '', error: `Not a file: ${resolved}` };
     if (stat.size > 512 * 1024)
       return { success: false, output: '', error: `File too large: ${stat.size} bytes` };
+
+    // JSONファイルが大きい場合は警告（profile_tool.py等のCLI経由を推奨）
+    if (resolved.endsWith('.json') && stat.size > 5 * 1024)
+      return {
+        success: false,
+        output: '',
+        error: `JSON file too large (${stat.size} bytes). Use a CLI tool to query specific entries instead of reading the entire file.`,
+      };
 
     try {
       return { success: true, output: readFileSync(resolved, 'utf-8') };

--- a/src/local-llm/types.ts
+++ b/src/local-llm/types.ts
@@ -26,6 +26,7 @@ export interface LLMChatOptions {
   temperature?: number;
   maxTokens?: number;
   systemPrompt?: string;
+  signal?: AbortSignal;
 }
 
 export interface LLMChatResponse {

--- a/src/persistent-runner.ts
+++ b/src/persistent-runner.ts
@@ -3,6 +3,7 @@ import { EventEmitter } from 'events';
 import type { RunOptions, RunResult, StreamCallbacks, AgentRunner } from './agent-runner.js';
 import { mergeTexts, sanitizeSurrogates } from './agent-runner.js';
 import { DEFAULT_TIMEOUT_MS } from './constants.js';
+import { getSafeEnv } from './base-runner.js';
 import { buildPersistentSystemPrompt } from './base-runner.js';
 import { logPrompt, logResponse, logError } from './transcript-logger.js';
 
@@ -117,6 +118,7 @@ export class PersistentRunner extends EventEmitter implements AgentRunner {
     this.process = spawn('claude', args, {
       stdio: ['pipe', 'pipe', 'pipe'],
       cwd: this.workdir,
+      env: getSafeEnv(),
     });
     this.processAlive = true;
 

--- a/src/safe-env.ts
+++ b/src/safe-env.ts
@@ -1,0 +1,40 @@
+/**
+ * AIエージェントに渡す環境変数のホワイトリスト
+ * ここに記載された変数のみ CLI/exec プロセスに渡される
+ * シークレット（トークン・APIキー等）は絶対に追加しないこと
+ */
+export const ALLOWED_ENV_KEYS = [
+  // シェル基本環境
+  'PATH',
+  'HOME',
+  'USER',
+  'SHELL',
+  'LANG',
+  'LC_ALL',
+  'LC_CTYPE',
+  'TERM',
+  'TMPDIR',
+  'TZ',
+  // Node.js
+  'NODE_ENV',
+  'NODE_PATH',
+  // xangi動作用
+  'WORKSPACE_PATH',
+  'AGENT_BACKEND',
+  'AGENT_MODEL',
+  'SKIP_PERMISSIONS',
+  'DATA_DIR',
+];
+
+/**
+ * ホワイトリスト方式で安全な環境変数のみ返す
+ */
+export function getSafeEnv(): NodeJS.ProcessEnv {
+  const env: NodeJS.ProcessEnv = {};
+  for (const key of ALLOWED_ENV_KEYS) {
+    if (process.env[key] !== undefined) {
+      env[key] = process.env[key];
+    }
+  }
+  return env;
+}

--- a/src/sessions.ts
+++ b/src/sessions.ts
@@ -1,15 +1,29 @@
 import { readFileSync, writeFileSync, mkdirSync, existsSync } from 'fs';
 import { join, dirname } from 'path';
+import { randomUUID } from 'crypto';
 
 /**
- * セッション管理（チャンネルID → Claude CodeセッションID）
+ * セッション管理（チャンネルID → セッション情報）
  * ファイルに永続化してプロセス再起動後も継続可能にする
  */
 
-type SessionMap = Map<string, string>;
+export type SessionScope = 'interactive' | 'scheduler';
+
+export interface SessionEntry {
+  sessionId: string;
+  scope: SessionScope;
+  bootId: string;
+  updatedAt: string;
+}
+
+// 後方互換: 旧フォーマット（string）も読み込み可能
+type RawSessionData = Record<string, string | SessionEntry>;
+
+type SessionMap = Map<string, SessionEntry>;
 
 let sessionsPath: string | null = null;
 let sessions: SessionMap = new Map();
+let currentBootId: string = randomUUID();
 
 /**
  * sessions.json のパスを初期化
@@ -17,7 +31,17 @@ let sessions: SessionMap = new Map();
  */
 export function initSessions(dataDir: string): void {
   sessionsPath = join(dataDir, 'sessions.json');
+  currentBootId = randomUUID();
   loadSessionsFromFile();
+  // 起動時: scheduler セッションをクリア（stateless化）
+  purgeSchedulerSessions();
+}
+
+/**
+ * 現在の bootId を取得
+ */
+export function getBootId(): string {
+  return currentBootId;
 }
 
 /**
@@ -31,15 +55,28 @@ export function getSessionsPath(): string {
 }
 
 /**
- * ファイルからセッションを読み込む
+ * ファイルからセッションを読み込む（旧フォーマットとの後方互換あり）
  */
 function loadSessionsFromFile(): void {
   const path = getSessionsPath();
   try {
     if (existsSync(path)) {
       const raw = readFileSync(path, 'utf-8');
-      const parsed = JSON.parse(raw) as Record<string, string>;
-      sessions = new Map(Object.entries(parsed));
+      const parsed = JSON.parse(raw) as RawSessionData;
+      sessions = new Map();
+      for (const [key, value] of Object.entries(parsed)) {
+        if (typeof value === 'string') {
+          // 旧フォーマット: string → SessionEntry に変換
+          sessions.set(key, {
+            sessionId: value,
+            scope: 'interactive',
+            bootId: '', // 不明（旧データ）
+            updatedAt: new Date().toISOString(),
+          });
+        } else {
+          sessions.set(key, value);
+        }
+      }
       console.log(`[xangi] Loaded ${sessions.size} sessions from ${path}`);
     }
   } catch (err) {
@@ -55,7 +92,10 @@ function saveSessionsToFile(): void {
   const path = getSessionsPath();
   try {
     mkdirSync(dirname(path), { recursive: true });
-    const obj = Object.fromEntries(sessions);
+    const obj: Record<string, SessionEntry> = {};
+    for (const [key, value] of sessions) {
+      obj[key] = value;
+    }
     writeFileSync(path, JSON.stringify(obj, null, 2) + '\n', 'utf-8');
   } catch (err) {
     console.error('[xangi] Failed to save sessions:', err);
@@ -63,17 +103,50 @@ function saveSessionsToFile(): void {
 }
 
 /**
+ * scheduler スコープのセッションを全削除（起動時に呼ばれる）
+ */
+function purgeSchedulerSessions(): void {
+  let purged = 0;
+  for (const [key, entry] of sessions) {
+    if (entry.scope === 'scheduler') {
+      sessions.delete(key);
+      purged++;
+    }
+  }
+  if (purged > 0) {
+    console.log(`[xangi] Purged ${purged} stale scheduler session(s)`);
+    saveSessionsToFile();
+  }
+}
+
+/**
  * セッションIDを取得
  */
 export function getSession(channelId: string): string | undefined {
+  return sessions.get(channelId)?.sessionId;
+}
+
+/**
+ * セッション情報を取得
+ */
+export function getSessionEntry(channelId: string): SessionEntry | undefined {
   return sessions.get(channelId);
 }
 
 /**
  * セッションIDを設定（自動保存）
  */
-export function setSession(channelId: string, sessionId: string): void {
-  sessions.set(channelId, sessionId);
+export function setSession(
+  channelId: string,
+  sessionId: string,
+  scope: SessionScope = 'interactive'
+): void {
+  sessions.set(channelId, {
+    sessionId,
+    scope,
+    bootId: currentBootId,
+    updatedAt: new Date().toISOString(),
+  });
   saveSessionsToFile();
 }
 

--- a/src/slack.ts
+++ b/src/slack.ts
@@ -238,7 +238,7 @@ export async function startSlackBot(options: SlackChannelOptions): Promise<void>
     if (!userId) return;
 
     // 許可リストチェック
-    if (!config.slack.allowedUsers?.includes(userId)) {
+    if (!config.slack.allowedUsers?.includes('*') && !config.slack.allowedUsers?.includes(userId)) {
       console.log(`[slack] Unauthorized user: ${userId}`);
       return;
     }
@@ -350,7 +350,10 @@ export async function startSlackBot(options: SlackChannelOptions): Promise<void>
     }
 
     // 許可リストチェック
-    if (!config.slack.allowedUsers?.includes(messageEvent.user)) {
+    if (
+      !config.slack.allowedUsers?.includes('*') &&
+      !config.slack.allowedUsers?.includes(messageEvent.user)
+    ) {
       console.log(`[slack] Unauthorized user: ${messageEvent.user}`);
       return;
     }
@@ -429,7 +432,10 @@ export async function startSlackBot(options: SlackChannelOptions): Promise<void>
   app.command('/new', async ({ command, ack, respond }) => {
     await ack();
 
-    if (!config.slack.allowedUsers?.includes(command.user_id)) {
+    if (
+      !config.slack.allowedUsers?.includes('*') &&
+      !config.slack.allowedUsers?.includes(command.user_id)
+    ) {
       await respond({ text: '許可されていないユーザーです', response_type: 'ephemeral' });
       return;
     }
@@ -442,7 +448,10 @@ export async function startSlackBot(options: SlackChannelOptions): Promise<void>
   app.command('/skills', async ({ command, ack, respond }) => {
     await ack();
 
-    if (!config.slack.allowedUsers?.includes(command.user_id)) {
+    if (
+      !config.slack.allowedUsers?.includes('*') &&
+      !config.slack.allowedUsers?.includes(command.user_id)
+    ) {
       await respond({ text: '許可されていないユーザーです', response_type: 'ephemeral' });
       return;
     }
@@ -457,7 +466,10 @@ export async function startSlackBot(options: SlackChannelOptions): Promise<void>
   app.command('/delete', async ({ command, ack, respond, client }) => {
     await ack();
 
-    if (!config.slack.allowedUsers?.includes(command.user_id)) {
+    if (
+      !config.slack.allowedUsers?.includes('*') &&
+      !config.slack.allowedUsers?.includes(command.user_id)
+    ) {
       await respond({ text: '許可されていないユーザーです', response_type: 'ephemeral' });
       return;
     }
@@ -470,7 +482,10 @@ export async function startSlackBot(options: SlackChannelOptions): Promise<void>
   app.command('/skill', async ({ command, ack, respond }) => {
     await ack();
 
-    if (!config.slack.allowedUsers?.includes(command.user_id)) {
+    if (
+      !config.slack.allowedUsers?.includes('*') &&
+      !config.slack.allowedUsers?.includes(command.user_id)
+    ) {
       await respond({ text: '許可されていないユーザーです', response_type: 'ephemeral' });
       return;
     }
@@ -508,7 +523,10 @@ export async function startSlackBot(options: SlackChannelOptions): Promise<void>
   app.command('/settings', async ({ command, ack, respond }) => {
     await ack();
 
-    if (!config.slack.allowedUsers?.includes(command.user_id)) {
+    if (
+      !config.slack.allowedUsers?.includes('*') &&
+      !config.slack.allowedUsers?.includes(command.user_id)
+    ) {
       await respond({ text: '許可されていないユーザーです', response_type: 'ephemeral' });
       return;
     }
@@ -521,7 +539,10 @@ export async function startSlackBot(options: SlackChannelOptions): Promise<void>
   app.command('/restart', async ({ command, ack, respond }) => {
     await ack();
 
-    if (!config.slack.allowedUsers?.includes(command.user_id)) {
+    if (
+      !config.slack.allowedUsers?.includes('*') &&
+      !config.slack.allowedUsers?.includes(command.user_id)
+    ) {
       await respond({ text: '許可されていないユーザーです', response_type: 'ephemeral' });
       return;
     }

--- a/tests/sessions.test.ts
+++ b/tests/sessions.test.ts
@@ -5,10 +5,12 @@ import { join } from 'path';
 import {
   initSessions,
   getSession,
+  getSessionEntry,
   setSession,
   deleteSession,
   clearSessions,
   getSessionCount,
+  getBootId,
 } from '../src/sessions.js';
 
 describe('sessions', () => {
@@ -43,6 +45,74 @@ describe('sessions', () => {
       expect(getSession('channel-1')).toBe('session-abc');
       expect(getSession('channel-2')).toBe('session-def');
     });
+
+    it('should migrate legacy string format to SessionEntry', () => {
+      const sessionsPath = join(testDir, 'sessions.json');
+      const data = { 'channel-1': 'session-abc' };
+      require('fs').writeFileSync(sessionsPath, JSON.stringify(data));
+
+      initSessions(testDir);
+      const entry = getSessionEntry('channel-1');
+      expect(entry).toBeDefined();
+      expect(entry!.sessionId).toBe('session-abc');
+      expect(entry!.scope).toBe('interactive');
+      expect(entry!.bootId).toBe(''); // 旧データは bootId 不明
+    });
+
+    it('should load new format sessions', () => {
+      const sessionsPath = join(testDir, 'sessions.json');
+      const data = {
+        'channel-1': {
+          sessionId: 'session-abc',
+          scope: 'interactive',
+          bootId: 'boot-xyz',
+          updatedAt: '2026-03-18T00:00:00Z',
+        },
+      };
+      require('fs').writeFileSync(sessionsPath, JSON.stringify(data));
+
+      initSessions(testDir);
+      const entry = getSessionEntry('channel-1');
+      expect(entry).toBeDefined();
+      expect(entry!.sessionId).toBe('session-abc');
+      expect(entry!.scope).toBe('interactive');
+      expect(entry!.bootId).toBe('boot-xyz');
+    });
+
+    it('should purge scheduler sessions on init', () => {
+      const sessionsPath = join(testDir, 'sessions.json');
+      const data = {
+        'channel-1': {
+          sessionId: 'session-abc',
+          scope: 'interactive',
+          bootId: 'boot-old',
+          updatedAt: '2026-03-18T00:00:00Z',
+        },
+        'channel-2': {
+          sessionId: 'session-def',
+          scope: 'scheduler',
+          bootId: 'boot-old',
+          updatedAt: '2026-03-18T00:00:00Z',
+        },
+      };
+      require('fs').writeFileSync(sessionsPath, JSON.stringify(data));
+
+      initSessions(testDir);
+      // interactive は残る
+      expect(getSession('channel-1')).toBe('session-abc');
+      // scheduler はクリアされる
+      expect(getSession('channel-2')).toBeUndefined();
+      expect(getSessionCount()).toBe(1);
+    });
+
+    it('should generate a new bootId on each init', () => {
+      initSessions(testDir);
+      const bootId1 = getBootId();
+      clearSessions();
+      initSessions(testDir);
+      const bootId2 = getBootId();
+      expect(bootId1).not.toBe(bootId2);
+    });
   });
 
   describe('getSession', () => {
@@ -68,7 +138,9 @@ describe('sessions', () => {
       expect(existsSync(sessionsPath)).toBe(true);
 
       const saved = JSON.parse(readFileSync(sessionsPath, 'utf-8'));
-      expect(saved['channel-1']).toBe('session-123');
+      expect(saved['channel-1'].sessionId).toBe('session-123');
+      expect(saved['channel-1'].scope).toBe('interactive');
+      expect(saved['channel-1'].bootId).toBe(getBootId());
     });
 
     it('should update existing session', () => {
@@ -77,6 +149,14 @@ describe('sessions', () => {
       setSession('channel-1', 'session-new');
 
       expect(getSession('channel-1')).toBe('session-new');
+    });
+
+    it('should save with scheduler scope', () => {
+      initSessions(testDir);
+      setSession('channel-1', 'session-123', 'scheduler');
+
+      const entry = getSessionEntry('channel-1');
+      expect(entry!.scope).toBe('scheduler');
     });
   });
 
@@ -115,6 +195,19 @@ describe('sessions', () => {
 
       expect(getSession('channel-1')).toBe('session-abc');
       expect(getSession('channel-2')).toBe('session-def');
+    });
+
+    it('should purge scheduler sessions but keep interactive on restart', () => {
+      initSessions(testDir);
+      setSession('channel-1', 'session-abc', 'interactive');
+      setSession('channel-2', 'session-def', 'scheduler');
+
+      // シミュレート: プロセス再起動
+      clearSessions();
+      initSessions(testDir);
+
+      expect(getSession('channel-1')).toBe('session-abc');
+      expect(getSession('channel-2')).toBeUndefined();
     });
   });
 });


### PR DESCRIPTION
# v0.11.0

## New Features

### マルチユーザー対応
- `DISCORD_ALLOWED_USER` / `SLACK_ALLOWED_USER` をカンマ区切りで複数ユーザー指定可能に
- `*` を指定すると全員許可（ローカルLLM利用時など制限不要な場合向け）
- プロンプトに `[発言者: 表示名 (ID: Discord_ID)]` を自動注入

### Docker + Ollama構成
- Ollamaコンテナを同梱（ホストにOllamaのインストール不要）
- `docker-compose.yml` を `env_file` 方式に変更（ホスト環境変数との衝突を防止）
- `XANGI_WORKSPACE` 環境変数でDockerのワークスペースマウント元を指定

### Local LLM改善
- コンテキスト刈り込み追加（`MAX_SESSION_MESSAGES: 50`、ツール結果8000文字上限）
- スキルパスをシステムプロンプトに明示
- `LOCAL_LLM_NUM_CTX` でOllamaのコンテキストウィンドウサイズを制限可能
- `/stop` 対応（AbortControllerでLLMリクエストを中断）
- ツール呼び出しログ出力追加

### セキュリティ
- 環境変数ホワイトリスト方式（`safe-env.ts`）を導入
- AIエージェントに `DISCORD_TOKEN` 等のシークレットが渡らないように
- Geminiバックエンドにもシステムプロンプト注入

## Bug Fixes

- スケジューラーをstateless化 + sessions.jsonスキーマ拡張
- リリーススクリプトで前回リリース済み変更を除外

## Documentation

- README: Docker + Local LLM（Ollama）セクション追加
- docs/usage.md: Local LLM設定、Docker操作方法を追加
- docs/design.md: Docker構成図を更新