### PR TITLE
Release v0.17.0

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -74,8 +74,8 @@ DISCORD_ALLOWED_USER=your_discord_user_id_here
 # 小さいほど応答が速い。未指定だとモデルの最大値（例: 262144）が使われて遅くなる
 # LOCAL_LLM_NUM_CTX=64000
 
-# Local LLMの動作モード（agent: ツール実行あり / chat: チャットのみ）
-# chatモードではtools/スキル/XANGI_COMMANDS/エージェントループを無効化
+# Local LLMの動作モード（agent: ツール実行あり / lite: トリガー+チャット）
+# liteモードではtools/スキル/XANGI_COMMANDS/エージェントループを無効化
 # LOCAL_LLM_MODE=agent
 
 # execツールのタイムアウト（ミリ秒、default: 120000 = 2min）
@@ -100,6 +100,14 @@ DISCORD_ALLOWED_USER=your_discord_user_id_here
 
 # Optional: Skip permissions by default (true/false, default: false)
 # SKIP_PERMISSIONS=false
+
+# ========================================
+# GitHub App認証（オプション、設定するとgh CLIにAppトークンを自動注入）
+# ========================================
+# 設定しなければ従来のgh認証（gh auth login / GH_TOKEN）をそのまま使用
+# GITHUB_APP_ID=1234567
+# GITHUB_APP_INSTALLATION_ID=12345678
+# GITHUB_APP_PRIVATE_KEY_PATH=/path/to/private-key.pem
 
 # ========================================
 # スケジューラ設定

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,6 +16,8 @@ x-common: &common
     - ./prompts:/app/prompts:ro
     # Git設定
     - ~/.gitconfig:/home/node/.gitconfig:ro
+    # GitHub App秘密鍵（オプション、設定時のみ有効）
+    - ${GITHUB_APP_PRIVATE_KEY_PATH:-/dev/null}:/secrets/github-app.pem:ro
   environment: &common-env
     # env_fileから読み込まれない固定値のみここに記述
     - NODE_ENV=production

--- a/docs/en/usage.md
+++ b/docs/en/usage.md
@@ -407,6 +407,61 @@ The Local LLM backend also saves transcript logs (`logs/transcripts/`). Prompts,
 
 For Docker deployment, see the [Docker Deployment](#docker-deployment) section.
 
+### Triggers (Lite Mode Extension)
+
+Even in lite mode where tool calls are not available, LLMs can invoke functionality by outputting magic words (`!command`) in their response text.
+
+#### Setup
+
+Create a `triggers/` directory in your workspace with subdirectories for each command:
+
+```
+workspace/
+  triggers/
+    weather/
+      trigger.yaml    # Trigger definition
+      handler.sh      # Handler script
+    search/
+      trigger.yaml
+      handler.sh
+```
+
+#### trigger.yaml Format
+
+```yaml
+name: weather
+trigger: "!weather"
+description: "Check the weather"
+handler: handler.sh
+```
+
+| Field | Required | Description |
+|-------|----------|-------------|
+| `name` | Yes | Trigger name |
+| `trigger` | Yes | Magic word (starts with `!`) |
+| `description` | No | Description (shown in system prompt) |
+| `handler` | Yes | Handler script filename |
+
+#### Handler Specification
+
+- Executed as `bash handler.sh [args...]` with workspace root as `cwd`
+- Arguments are passed as space-separated command line args (e.g., `!weather Tokyo` → `bash handler.sh Tokyo`)
+- Timeout: `EXEC_TIMEOUT_MS` (default 120 seconds)
+- `stdout` content is sent to Discord
+
+#### How It Works
+
+1. On startup, xangi scans the workspace `triggers/` directory
+2. Available triggers are added to the system prompt
+3. When the LLM response contains a trigger word, the handler is executed
+4. Handler output is sent to Discord
+
+#### Notes
+
+- **Chat mode only**. Triggers are ignored in agent mode
+- Triggers scan the entire LLM response text line by line
+- If multiple triggers match in one response, only the first match is executed
+
 ### Multimodal (Image Input)
 
 The Local LLM backend supports image input. When you send a message with an image attachment via Discord/Slack, the image content is passed to the LLM for analysis and description.
@@ -506,6 +561,22 @@ To modify the whitelist, edit `ALLOWED_ENV_KEYS` in `src/safe-env.ts`.
 | `IDLE_TIMEOUT_MS` | Auto-terminate idle processes after | `1800000` |
 | `DATA_DIR` | Data storage directory | `.xangi` |
 | `GH_TOKEN` | GitHub CLI token | - |
+
+### GitHub App Authentication (Optional)
+
+When GitHub App settings are configured, installation tokens are auto-generated on each `gh` CLI execution. No PAT or `gh auth login` needed.
+
+| Variable | Description |
+|----------|-------------|
+| `GITHUB_APP_ID` | GitHub App ID |
+| `GITHUB_APP_INSTALLATION_ID` | Installation ID |
+| `GITHUB_APP_PRIVATE_KEY_PATH` | Private key file path |
+
+Without these settings, existing `gh` authentication (`gh auth login` / `GH_TOKEN`) is used as-is.
+
+**Docker:** The private key is auto-mounted to `/secrets/github-app.pem`. Set the host-side path in `.env`.
+
+**Security:** If token generation fails, it does NOT fall back to PAT — it errors out. A `🔑App` badge appears in tool display when `gh` runs.
 
 ### Local LLM (when `AGENT_BACKEND=local-llm`)
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -405,23 +405,81 @@ Local LLMバックエンドでもトランスクリプトログ（`logs/transcri
 
 Docker実行については [Docker実行](#docker実行) セクションを参照してください。
 
-### チャットモード
+### liteモード
 
-tools非対応モデルや小型モデルを雑談ボットとして使いたい場合は、`LOCAL_LLM_MODE=chat` を設定します。
+tools非対応モデルや小型モデルを雑談ボットとして使いたい場合は、`LOCAL_LLM_MODE=lite` を設定します。
 
 ```bash
 # .env
-LOCAL_LLM_MODE=chat
+LOCAL_LLM_MODE=lite
 ```
 
-チャットモードでは以下が無効化されます：
+liteモードでは以下が無効化されます：
 
 - **tools送信** — Ollama APIにtoolsフィールドを送らないため、tools非対応モデルでも400エラーにならない
 - **スキル一覧** — システムプロンプトから除外
 - **XANGI_COMMANDS / CHAT_SYSTEM_PROMPT** — システムプロンプトから除外
 - **エージェントループ** — 1回のLLM呼び出しで完了（ツール実行なし）
 
-ワークスペースコンテキスト（AGENTS.md等）はチャットモードでも注入されます。
+ワークスペースコンテキスト（AGENTS.md等）はliteモードでも注入されます。
+
+### Triggers（liteモード拡張）
+
+liteモードでツールコール不可のモデルでも、LLMがテキストでマジックワード（`!コマンド名`）を出力するだけで機能を発動できる仕組みです。
+
+#### セットアップ
+
+ワークスペースに `triggers/` ディレクトリを作成し、コマンドごとにサブディレクトリを配置します。
+
+```
+workspace/
+  triggers/
+    weather/
+      trigger.yaml    # トリガー定義
+      handler.sh      # 実行スクリプト
+    search/
+      trigger.yaml
+      handler.sh
+```
+
+#### trigger.yaml フォーマット
+
+```yaml
+name: weather
+trigger: "!weather"
+description: "天気を調べる"
+handler: handler.sh
+feedback: true   # handler結果をLLMに戻してキャラに合った応答を生成
+```
+
+| フィールド | 必須 | 説明 |
+|-----------|------|------|
+| `name` | Yes | トリガー名 |
+| `trigger` | Yes | マジックワード（`!` で始まる） |
+| `description` | No | 説明（システムプロンプトに表示される） |
+| `handler` | Yes | 実行スクリプトのファイル名 |
+| `feedback` | No | `true`にするとhandler結果をLLMに戻して再応答（デフォルト: `false`） |
+
+#### handler の仕様
+
+- ワークスペースルートを `cwd` として `bash handler.sh [引数...]` で実行
+- 引数はトリガーワードの後のテキストをスペース区切りで渡す（例: `!weather 名古屋` → `bash handler.sh 名古屋`）
+- タイムアウト: `EXEC_TIMEOUT_MS`（デフォルト120秒）
+- `stdout` の内容がDiscordに送信される
+
+#### 動作フロー
+
+1. xangi起動時にワークスペースの `triggers/` をスキャン
+2. 利用可能なトリガー一覧がシステムプロンプトに追加される
+3. LLMの応答テキストにトリガーワードが含まれていたら handler を実行
+4. `feedback: false`（デフォルト）: handler の出力をそのままDiscordに送信
+5. `feedback: true`: handler の出力をLLMに戻して再応答。キャラクターに合った返答を生成
+
+#### 注意事項
+
+- **liteモード専用**。agentモードではtriggersは無視されます
+- トリガーはLLMの応答テキスト全体を行単位でスキャンします
+- 1つの応答で複数のトリガーがマッチした場合、最初にマッチしたものだけが実行されます
 
 ### マルチモーダル（画像入力）
 
@@ -523,12 +581,28 @@ AIエージェント（CLI spawn / Local LLM exec）に渡す環境変数は `sr
 | `DATA_DIR` | データ保存ディレクトリ | `.xangi` |
 | `GH_TOKEN` | GitHub CLIトークン | - |
 
+### GitHub App認証（オプション）
+
+GitHub App設定があれば、`gh` CLI実行時にインストールトークンを自動生成。PATや `gh auth login` が不要に。
+
+| 変数 | 説明 |
+|------|------|
+| `GITHUB_APP_ID` | GitHub App ID |
+| `GITHUB_APP_INSTALLATION_ID` | インストールID |
+| `GITHUB_APP_PRIVATE_KEY_PATH` | 秘密鍵ファイルパス |
+
+設定しなければ従来の `gh` 認証（`gh auth login` / `GH_TOKEN`）をそのまま使用。
+
+**Docker環境:** 秘密鍵は `/secrets/github-app.pem` に自動マウントされます。`.env` にはホスト側のパスを設定してください。
+
+**セキュリティ:** トークン生成に失敗した場合、PATへのフォールバックは行わずエラーになります。`gh` 実行時にツール表示に `🔑App` バッジが表示されます。
+
 ### Local LLM（`AGENT_BACKEND=local-llm` 時）
 
 | 変数 | 説明 | デフォルト |
 |------|------|-----------|
 | `LOCAL_LLM_BASE_URL` | LLMサーバーURL | `http://localhost:11434` |
-| `LOCAL_LLM_MODE` | 動作モード（`agent`: ツール実行あり / `chat`: チャットのみ） | `agent` |
+| `LOCAL_LLM_MODE` | 動作モード（`agent`: ツール実行あり / `lite`: トリガー+チャット） | `agent` |
 | `LOCAL_LLM_MODEL` | 使用するモデル名 | - |
 | `LOCAL_LLM_API_KEY` | APIキー（vLLM等で必要な場合） | - |
 | `LOCAL_LLM_THINKING` | Thinkingモデルの推論を有効にするか | `true` |

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.1.0",
       "license": "MIT",
       "dependencies": {
+        "@octokit/auth-app": "^8.2.0",
         "@slack/bolt": "^4.6.0",
         "discord.js": "^14.16.3",
         "dotenv": "^17.3.1",
@@ -855,6 +856,153 @@
       "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@octokit/auth-app": {
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/@octokit/auth-app/-/auth-app-8.2.0.tgz",
+      "integrity": "sha512-vVjdtQQwomrZ4V46B9LaCsxsySxGoHsyw6IYBov/TqJVROrlYdyNgw5q6tQbB7KZt53v1l1W53RiqTvpzL907g==",
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/auth-oauth-app": "^9.0.3",
+        "@octokit/auth-oauth-user": "^6.0.2",
+        "@octokit/request": "^10.0.6",
+        "@octokit/request-error": "^7.0.2",
+        "@octokit/types": "^16.0.0",
+        "toad-cache": "^3.7.0",
+        "universal-github-app-jwt": "^2.2.0",
+        "universal-user-agent": "^7.0.0"
+      },
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@octokit/auth-oauth-app": {
+      "version": "9.0.3",
+      "resolved": "https://registry.npmjs.org/@octokit/auth-oauth-app/-/auth-oauth-app-9.0.3.tgz",
+      "integrity": "sha512-+yoFQquaF8OxJSxTb7rnytBIC2ZLbLqA/yb71I4ZXT9+Slw4TziV9j/kyGhUFRRTF2+7WlnIWsePZCWHs+OGjg==",
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/auth-oauth-device": "^8.0.3",
+        "@octokit/auth-oauth-user": "^6.0.2",
+        "@octokit/request": "^10.0.6",
+        "@octokit/types": "^16.0.0",
+        "universal-user-agent": "^7.0.0"
+      },
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@octokit/auth-oauth-device": {
+      "version": "8.0.3",
+      "resolved": "https://registry.npmjs.org/@octokit/auth-oauth-device/-/auth-oauth-device-8.0.3.tgz",
+      "integrity": "sha512-zh2W0mKKMh/VWZhSqlaCzY7qFyrgd9oTWmTmHaXnHNeQRCZr/CXy2jCgHo4e4dJVTiuxP5dLa0YM5p5QVhJHbw==",
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/oauth-methods": "^6.0.2",
+        "@octokit/request": "^10.0.6",
+        "@octokit/types": "^16.0.0",
+        "universal-user-agent": "^7.0.0"
+      },
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@octokit/auth-oauth-user": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/@octokit/auth-oauth-user/-/auth-oauth-user-6.0.2.tgz",
+      "integrity": "sha512-qLoPPc6E6GJoz3XeDG/pnDhJpTkODTGG4kY0/Py154i/I003O9NazkrwJwRuzgCalhzyIeWQ+6MDvkUmKXjg/A==",
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/auth-oauth-device": "^8.0.3",
+        "@octokit/oauth-methods": "^6.0.2",
+        "@octokit/request": "^10.0.6",
+        "@octokit/types": "^16.0.0",
+        "universal-user-agent": "^7.0.0"
+      },
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@octokit/endpoint": {
+      "version": "11.0.3",
+      "resolved": "https://registry.npmjs.org/@octokit/endpoint/-/endpoint-11.0.3.tgz",
+      "integrity": "sha512-FWFlNxghg4HrXkD3ifYbS/IdL/mDHjh9QcsNyhQjN8dplUoZbejsdpmuqdA76nxj2xoWPs7p8uX2SNr9rYu0Ag==",
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/types": "^16.0.0",
+        "universal-user-agent": "^7.0.2"
+      },
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@octokit/oauth-authorization-url": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/@octokit/oauth-authorization-url/-/oauth-authorization-url-8.0.0.tgz",
+      "integrity": "sha512-7QoLPRh/ssEA/HuHBHdVdSgF8xNLz/Bc5m9fZkArJE5bb6NmVkDm3anKxXPmN1zh6b5WKZPRr3697xKT/yM3qQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@octokit/oauth-methods": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/@octokit/oauth-methods/-/oauth-methods-6.0.2.tgz",
+      "integrity": "sha512-HiNOO3MqLxlt5Da5bZbLV8Zarnphi4y9XehrbaFMkcoJ+FL7sMxH/UlUsCVxpddVu4qvNDrBdaTVE2o4ITK8ng==",
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/oauth-authorization-url": "^8.0.0",
+        "@octokit/request": "^10.0.6",
+        "@octokit/request-error": "^7.0.2",
+        "@octokit/types": "^16.0.0"
+      },
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@octokit/openapi-types": {
+      "version": "27.0.0",
+      "resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-27.0.0.tgz",
+      "integrity": "sha512-whrdktVs1h6gtR+09+QsNk2+FO+49j6ga1c55YZudfEG+oKJVvJLQi3zkOm5JjiUXAagWK2tI2kTGKJ2Ys7MGA==",
+      "license": "MIT"
+    },
+    "node_modules/@octokit/request": {
+      "version": "10.0.8",
+      "resolved": "https://registry.npmjs.org/@octokit/request/-/request-10.0.8.tgz",
+      "integrity": "sha512-SJZNwY9pur9Agf7l87ywFi14W+Hd9Jg6Ifivsd33+/bGUQIjNujdFiXII2/qSlN2ybqUHfp5xpekMEjIBTjlSw==",
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/endpoint": "^11.0.3",
+        "@octokit/request-error": "^7.0.2",
+        "@octokit/types": "^16.0.0",
+        "fast-content-type-parse": "^3.0.0",
+        "json-with-bigint": "^3.5.3",
+        "universal-user-agent": "^7.0.2"
+      },
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@octokit/request-error": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/@octokit/request-error/-/request-error-7.1.0.tgz",
+      "integrity": "sha512-KMQIfq5sOPpkQYajXHwnhjCC0slzCNScLHs9JafXc4RAJI+9f+jNDlBNaIMTvazOPLgb4BnlhGJOTbnN0wIjPw==",
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/types": "^16.0.0"
+      },
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@octokit/types": {
+      "version": "16.0.0",
+      "resolved": "https://registry.npmjs.org/@octokit/types/-/types-16.0.0.tgz",
+      "integrity": "sha512-sKq+9r1Mm4efXW1FCk7hFSeJo4QKreL/tTbR0rz/qx/r1Oa2VV83LTA/H/MuCOX7uCIJmQVRKBcbmWoySjAnSg==",
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/openapi-types": "^27.0.0"
+      }
     },
     "node_modules/@rollup/rollup-android-arm-eabi": {
       "version": "4.57.1",
@@ -2864,6 +3012,22 @@
         "url": "https://opencollective.com/express"
       }
     },
+    "node_modules/fast-content-type-parse": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/fast-content-type-parse/-/fast-content-type-parse-3.0.0.tgz",
+      "integrity": "sha512-ZvLdcY8P+N8mGQJahJV5G4U88CSvT1rP8ApL6uETe88MBXrBHAkZlSEySdUlyztF7ccb+Znos3TFqaepHxdhBg==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "MIT"
+    },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
@@ -3434,6 +3598,12 @@
       "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
       "integrity": "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/json-with-bigint": {
+      "version": "3.5.8",
+      "resolved": "https://registry.npmjs.org/json-with-bigint/-/json-with-bigint-3.5.8.tgz",
+      "integrity": "sha512-eq/4KP6K34kwa7TcFdtvnftvHCD9KvHOGGICWwMFc4dOOKF5t4iYqnfLK8otCRCRv06FXOzGGyqE8h8ElMvvdw==",
       "license": "MIT"
     },
     "node_modules/jsonwebtoken": {
@@ -4739,6 +4909,15 @@
         "node": ">=8.0"
       }
     },
+    "node_modules/toad-cache": {
+      "version": "3.7.0",
+      "resolved": "https://registry.npmjs.org/toad-cache/-/toad-cache-3.7.0.tgz",
+      "integrity": "sha512-/m8M+2BJUpoJdgAHoG+baCwBT+tf2VraSfkBgl0Y00qIWt41DJ8R5B8nsEw0I58YwF5IZH6z24/2TobDKnqSWw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/toidentifier": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
@@ -4881,6 +5060,18 @@
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
       "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
       "license": "MIT"
+    },
+    "node_modules/universal-github-app-jwt": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/universal-github-app-jwt/-/universal-github-app-jwt-2.2.2.tgz",
+      "integrity": "sha512-dcmbeSrOdTnsjGjUfAlqNDJrhxXizjAz94ija9Qw8YkZ1uu0d+GoZzyH+Jb9tIIqvGsadUfwg+22k5aDqqwzbw==",
+      "license": "MIT"
+    },
+    "node_modules/universal-user-agent": {
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/universal-user-agent/-/universal-user-agent-7.0.3.tgz",
+      "integrity": "sha512-TmnEAEAsBJVZM/AADELsK76llnwcf9vMKuPz8JflO1frO8Lchitr0fNaN9d+Ap0BjKtqWqd/J17qeDnXh8CL2A==",
+      "license": "ISC"
     },
     "node_modules/unpipe": {
       "version": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
   "author": "karaage",
   "license": "MIT",
   "dependencies": {
+    "@octokit/auth-app": "^8.2.0",
     "@slack/bolt": "^4.6.0",
     "discord.js": "^14.16.3",
     "dotenv": "^17.3.1",

--- a/src/claude-code.ts
+++ b/src/claude-code.ts
@@ -4,6 +4,7 @@ import type { RunOptions, RunResult, StreamCallbacks } from './agent-runner.js';
 import { mergeTexts, sanitizeSurrogates } from './agent-runner.js';
 import { DEFAULT_TIMEOUT_MS } from './constants.js';
 import { getSafeEnv } from './base-runner.js';
+import { getGitHubEnv } from './github-auth.js';
 import { buildSystemPrompt } from './base-runner.js';
 import type { ChatPlatform } from './prompts/index.js';
 import { logPrompt, logResponse } from './transcript-logger.js';
@@ -95,11 +96,12 @@ export class ClaudeCodeRunner {
   }
 
   private execute(args: string[], channelId?: string): Promise<string> {
+    const safeEnv = getSafeEnv();
     return new Promise((resolve, reject) => {
       const proc = spawn('claude', args, {
         stdio: ['ignore', 'pipe', 'pipe'],
         cwd: this.workdir,
-        env: getSafeEnv(),
+        env: { ...safeEnv, ...getGitHubEnv(safeEnv) },
       });
 
       // プロセスマネージャーに登録
@@ -200,11 +202,12 @@ export class ClaudeCodeRunner {
     callbacks: StreamCallbacks,
     channelId?: string
   ): Promise<RunResult> {
+    const safeEnv = getSafeEnv();
     return new Promise((resolve, reject) => {
       const proc = spawn('claude', args, {
         stdio: ['ignore', 'pipe', 'pipe'],
         cwd: this.workdir,
-        env: getSafeEnv(),
+        env: { ...safeEnv, ...getGitHubEnv(safeEnv) },
       });
 
       // プロセスマネージャーに登録

--- a/src/codex-cli.ts
+++ b/src/codex-cli.ts
@@ -3,6 +3,7 @@ import { processManager } from './process-manager.js';
 import type { AgentRunner, RunOptions, RunResult, StreamCallbacks } from './agent-runner.js';
 import { DEFAULT_TIMEOUT_MS } from './constants.js';
 import { buildSystemPrompt, getSafeEnv } from './base-runner.js';
+import { getGitHubEnv } from './github-auth.js';
 import { logPrompt, logResponse } from './transcript-logger.js';
 
 export interface CodexOptions {
@@ -153,11 +154,12 @@ export class CodexRunner implements AgentRunner {
     args: string[],
     channelId?: string
   ): Promise<{ stdout: string; sessionId: string }> {
+    const safeEnv = getSafeEnv();
     return new Promise((resolve, reject) => {
       const proc = spawn('codex', args, {
         stdio: ['ignore', 'pipe', 'pipe'],
         cwd: this.workdir,
-        env: getSafeEnv(),
+        env: { ...safeEnv, ...getGitHubEnv(safeEnv) },
       });
       this.currentProcess = proc;
 
@@ -267,11 +269,12 @@ export class CodexRunner implements AgentRunner {
     callbacks: StreamCallbacks,
     channelId?: string
   ): Promise<RunResult> {
+    const safeEnv = getSafeEnv();
     return new Promise((resolve, reject) => {
       const proc = spawn('codex', args, {
         stdio: ['ignore', 'pipe', 'pipe'],
         cwd: this.workdir,
-        env: getSafeEnv(),
+        env: { ...safeEnv, ...getGitHubEnv(safeEnv) },
       });
       this.currentProcess = proc;
 

--- a/src/gemini-cli.ts
+++ b/src/gemini-cli.ts
@@ -4,6 +4,7 @@ import type { AgentRunner, RunOptions, RunResult, StreamCallbacks } from './agen
 import { DEFAULT_TIMEOUT_MS } from './constants.js';
 import { getSafeEnv, buildSystemPrompt } from './base-runner.js';
 import type { BaseRunnerOptions } from './base-runner.js';
+import { getGitHubEnv } from './github-auth.js';
 import { logPrompt, logResponse } from './transcript-logger.js';
 
 /**
@@ -150,11 +151,12 @@ export class GeminiRunner implements AgentRunner {
     args: string[],
     channelId?: string
   ): Promise<{ stdout: string; sessionId: string }> {
+    const safeEnv = getSafeEnv();
     return new Promise((resolve, reject) => {
       const proc = spawn('gemini', args, {
         stdio: ['ignore', 'pipe', 'pipe'],
         cwd: this.workdir,
-        env: getSafeEnv(),
+        env: { ...safeEnv, ...getGitHubEnv(safeEnv) },
       });
       this.currentProcess = proc;
 
@@ -271,11 +273,12 @@ export class GeminiRunner implements AgentRunner {
     callbacks: StreamCallbacks,
     channelId?: string
   ): Promise<RunResult> {
+    const safeEnv = getSafeEnv();
     return new Promise((resolve, reject) => {
       const proc = spawn('gemini', args, {
         stdio: ['ignore', 'pipe', 'pipe'],
         cwd: this.workdir,
-        env: getSafeEnv(),
+        env: { ...safeEnv, ...getGitHubEnv(safeEnv) },
       });
       this.currentProcess = proc;
 

--- a/src/github-auth.ts
+++ b/src/github-auth.ts
@@ -1,0 +1,110 @@
+/**
+ * GitHub App認証
+ *
+ * GitHub App設定があれば gh ラッパースクリプトを自動生成し、
+ * エージェントの PATH に差し込む。gh 実行時に毎回トークンを生成。
+ * 設定がなければ既存の gh 認証をそのまま使用。
+ */
+import { writeFileSync, mkdirSync, chmodSync, existsSync } from 'fs';
+import { join, dirname } from 'path';
+
+interface GitHubAppConfig {
+  appId: string;
+  installationId: string;
+  privateKeyPath: string;
+}
+
+let appConfig: GitHubAppConfig | null = null;
+
+// ラッパースクリプトの配置先
+const WRAPPER_DIR = '/tmp/xangi-gh-wrapper';
+const WRAPPER_PATH = join(WRAPPER_DIR, 'gh');
+
+// トークン生成スクリプト
+const TOKEN_SCRIPT_PATH = join(WRAPPER_DIR, 'generate-token.cjs');
+
+/**
+ * GitHub App設定を初期化しラッパーを生成
+ */
+export function initGitHubAuth(): void {
+  const appId = process.env.GITHUB_APP_ID;
+  const installationId = process.env.GITHUB_APP_INSTALLATION_ID;
+  const privateKeyPath = process.env.GITHUB_APP_PRIVATE_KEY_PATH;
+
+  if (appId && installationId && privateKeyPath) {
+    // Docker環境ではマウント先の固定パスを使用
+    const dockerPemPath = '/secrets/github-app.pem';
+    const resolvedKeyPath = existsSync(dockerPemPath) ? dockerPemPath : privateKeyPath;
+    appConfig = { appId, installationId, privateKeyPath: resolvedKeyPath };
+    generateWrapper(appConfig);
+    console.log(`[github-auth] GitHub App mode enabled (App ID: ${appId})`);
+  } else {
+    console.log('[github-auth] Using default gh authentication');
+  }
+}
+
+/**
+ * GitHub App が有効かどうか
+ */
+export function isGitHubAppEnabled(): boolean {
+  return appConfig !== null;
+}
+
+/**
+ * エージェントの PATH に追加すべきディレクトリ
+ * App モード: ラッパーディレクトリを返す
+ * 通常モード: undefined
+ */
+export function getGitHubWrapperDir(): string | undefined {
+  return appConfig ? WRAPPER_DIR : undefined;
+}
+
+/**
+ * エージェントプロセスに渡す環境変数を取得
+ * App モード: PATH にラッパーディレクトリを先頭追加
+ * 通常モード: 空オブジェクト
+ */
+export function getGitHubEnv(
+  baseEnv: NodeJS.ProcessEnv | Record<string, string>
+): Record<string, string> {
+  if (!appConfig) return {};
+  const currentPath = baseEnv['PATH'] || process.env.PATH || '';
+  return { PATH: `${WRAPPER_DIR}:${currentPath}` };
+}
+
+/**
+ * ラッパースクリプトとトークン生成スクリプトを生成
+ */
+function generateWrapper(config: GitHubAppConfig): void {
+  mkdirSync(WRAPPER_DIR, { recursive: true });
+
+  // Node.js トークン生成スクリプト（CommonJS形式、@octokit/auth-app使用）
+  const tokenScript = `const { createAppAuth } = require('@octokit/auth-app');
+const { readFileSync } = require('fs');
+(async () => {
+  const auth = createAppAuth({
+    appId: '${config.appId}',
+    privateKey: readFileSync('${config.privateKeyPath}', 'utf-8'),
+    installationId: ${config.installationId},
+  });
+  const { token } = await auth({ type: 'installation' });
+  process.stdout.write(token);
+})();
+`;
+  writeFileSync(TOKEN_SCRIPT_PATH, tokenScript, 'utf-8');
+
+  // gh ラッパーシェルスクリプト
+  // CJS形式なのでNODE_PATHでnode_modulesを参照
+  const xangiDir = join(dirname(new URL(import.meta.url).pathname), '..');
+  const wrapper = `#!/bin/bash
+export GH_TOKEN="$(NODE_PATH="${xangiDir}/node_modules" node "${TOKEN_SCRIPT_PATH}")"
+if [ -z "$GH_TOKEN" ]; then
+  echo "Error: Failed to generate GitHub App token" >&2
+  exit 1
+fi
+echo "[github-auth] Using GitHub App token (App ID: ${config.appId})" >&2
+exec "$(which -a gh | grep -v "${WRAPPER_DIR}" | head -1)" "$@"
+`;
+  writeFileSync(WRAPPER_PATH, wrapper, 'utf-8');
+  chmodSync(WRAPPER_PATH, 0o755);
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -13,6 +13,7 @@ import {
   ButtonStyle,
 } from 'discord.js';
 import { loadConfig } from './config.js';
+import { isGitHubAppEnabled } from './github-auth.js';
 import { createAgentRunner, getBackendDisplayName, type AgentRunner } from './agent-runner.js';
 import { ClaudeCodeRunner } from './claude-code.js';
 import { processManager } from './process-manager.js';
@@ -122,10 +123,13 @@ function formatToolInput(toolName: string, input: Record<string, unknown>): stri
     case 'Edit':
     case 'Write':
       return input.file_path ? `: ${String(input.file_path).split('/').slice(-2).join('/')}` : '';
-    case 'Bash':
-      return input.command
-        ? `: \`${String(input.command).slice(0, 60)}${String(input.command).length > 60 ? '...' : ''}\``
-        : '';
+    case 'Bash': {
+      if (!input.command) return '';
+      const cmd = String(input.command);
+      const cmdDisplay = `: \`${cmd.slice(0, 60)}${cmd.length > 60 ? '...' : ''}\``;
+      const ghBadge = cmd.startsWith('gh ') && isGitHubAppEnabled() ? ' 🔑App' : '';
+      return cmdDisplay + ghBadge;
+    }
     case 'Glob':
       return input.pattern ? `: ${String(input.pattern)}` : '';
     case 'Grep':
@@ -208,6 +212,10 @@ async function main() {
 
   // セッション永続化を初期化
   initSessions(dataDir);
+
+  // GitHub認証を初期化
+  const { initGitHubAuth } = await import('./github-auth.js');
+  initGitHubAuth();
 
   // スラッシュコマンド定義
   const commands: ReturnType<SlashCommandBuilder['toJSON']>[] = [

--- a/src/local-llm/runner.ts
+++ b/src/local-llm/runner.ts
@@ -14,6 +14,13 @@ import { getBuiltinTools, toLLMTools, executeTool } from './tools.js';
 import { loadSkills } from '../skills.js';
 import { CHAT_SYSTEM_PROMPT_PERSISTENT, XANGI_COMMANDS } from '../base-runner.js';
 import { logPrompt, logResponse, logError } from '../transcript-logger.js';
+import {
+  loadTriggers,
+  matchTrigger,
+  executeTrigger,
+  buildTriggersPrompt,
+  type Trigger,
+} from './triggers.js';
 
 const MAX_TOOL_ROUNDS = 10;
 const MAX_SESSION_MESSAGES = 50;
@@ -86,8 +93,10 @@ export class LocalLlmRunner implements AgentRunner {
   private readonly sessions = new Map<string, Session>();
   private readonly sessionTtlMs = 60 * 60 * 1000; // 1時間
   private readonly activeAbortControllers = new Map<string, AbortController>();
-  /** chatモード: tools/スキル/XANGI_COMMANDS無効、1回のLLM呼び出しで完了 */
-  readonly chatMode: boolean;
+  /** liteモード: tools/スキル/XANGI_COMMANDS無効、1回のLLM呼び出しで完了 */
+  readonly liteMode: boolean;
+  /** liteモード用トリガー定義 */
+  private triggers: Trigger[];
 
   constructor(config: AgentConfig) {
     const baseUrl = (process.env.LOCAL_LLM_BASE_URL || 'http://localhost:11434').replace(/\/$/, '');
@@ -101,16 +110,22 @@ export class LocalLlmRunner implements AgentRunner {
       ? parseInt(process.env.LOCAL_LLM_NUM_CTX, 10)
       : undefined;
 
-    // LOCAL_LLM_MODE: "agent" (default) or "chat"
+    // LOCAL_LLM_MODE: "agent" (default) or "lite"
     const modeEnv = (process.env.LOCAL_LLM_MODE || 'agent').toLowerCase();
-    this.chatMode = modeEnv === 'chat';
+    this.liteMode = modeEnv === 'lite';
 
     this.llm = new LLMClient(baseUrl, model, apiKey, thinking, maxTokens, numCtx);
     this.workdir = config.workdir || process.cwd();
 
+    // liteモード用トリガーを読み込み
+    this.triggers = this.liteMode ? loadTriggers(this.workdir) : [];
+
     console.log(
-      `[local-llm] LLM: ${baseUrl} (model: ${model}, thinking: ${thinking}, mode: ${this.chatMode ? 'chat' : 'agent'})`
+      `[local-llm] LLM: ${baseUrl} (model: ${model}, thinking: ${thinking}, mode: ${this.liteMode ? 'lite' : 'agent'})`
     );
+    if (this.triggers.length > 0) {
+      console.log(`[local-llm] Triggers loaded: ${this.triggers.map((t) => t.trigger).join(', ')}`);
+    }
   }
 
   async run(prompt: string, options?: RunOptions): Promise<RunResult> {
@@ -119,8 +134,8 @@ export class LocalLlmRunner implements AgentRunner {
 
     const session = this.getOrCreateSession(sessionId);
     const systemPrompt = this.buildSystemPrompt();
-    const tools = this.chatMode ? [] : getBuiltinTools();
-    const llmTools = this.chatMode ? [] : toLLMTools(tools);
+    const tools = this.liteMode ? [] : getBuiltinTools();
+    const llmTools = this.liteMode ? [] : toLLMTools(tools);
 
     // ユーザーメッセージ追加（画像添付があればマルチモーダルメッセージにする）
     const userMsg = this.buildUserMessage(prompt);
@@ -222,8 +237,8 @@ export class LocalLlmRunner implements AgentRunner {
 
     const session = this.getOrCreateSession(sessionId);
     const systemPrompt = this.buildSystemPrompt();
-    const tools = this.chatMode ? [] : getBuiltinTools();
-    const llmTools = this.chatMode ? [] : toLLMTools(tools);
+    const tools = this.liteMode ? [] : getBuiltinTools();
+    const llmTools = this.liteMode ? [] : toLLMTools(tools);
 
     const userMsg = this.buildUserMessage(prompt);
     session.messages.push(userMsg);
@@ -248,13 +263,44 @@ export class LocalLlmRunner implements AgentRunner {
       );
 
       session.messages.push({ role: 'assistant', content: fullText });
+
+      // トリガー検出・実行（liteモードのみ）
+      let finalText = fullText;
+      const triggerResult = await this.processTriggers(fullText, channelId, sessionId);
+      if (triggerResult !== null) {
+        const match = matchTrigger(fullText, this.triggers);
+        if (match?.trigger.feedback) {
+          // feedback: handler結果をLLMに戻して再応答
+          session.messages.push({
+            role: 'user',
+            content: `[${match.trigger.name}の結果]\n${triggerResult}`,
+          });
+          try {
+            const feedbackResponse = await this.llm.chat(session.messages, {
+              systemPrompt: this.buildSystemPrompt(),
+              signal: abortController.signal,
+            });
+            session.messages.push({ role: 'assistant', content: feedbackResponse.content });
+            finalText = feedbackResponse.content;
+            callbacks.onText?.(feedbackResponse.content, feedbackResponse.content);
+          } catch {
+            finalText = fullText + '\n\n' + triggerResult;
+            callbacks.onText?.('\n\n' + triggerResult, finalText);
+          }
+        } else {
+          // feedback: false — LLM応答 + trigger結果を表示
+          finalText = fullText + '\n\n' + triggerResult;
+          callbacks.onText?.('\n\n' + triggerResult, finalText);
+        }
+      }
+
       this.trimSession(session);
       session.updatedAt = Date.now();
 
       // トランスクリプトにレスポンスを記録
-      logResponse(this.workdir, channelId, { result: fullText, sessionId });
+      logResponse(this.workdir, channelId, { result: finalText, sessionId });
 
-      const result: RunResult = { result: fullText, sessionId };
+      const result: RunResult = { result: finalText, sessionId };
       callbacks.onComplete?.(result);
       return result;
     } catch (err) {
@@ -343,7 +389,7 @@ export class LocalLlmRunner implements AgentRunner {
 
   /**
    * エージェントループ（run用）: ツール呼び出しを含む非ストリーミング実行
-   * chatモードではツールなしの1回呼び出しで完了する。
+   * liteモードではツールなしの1回呼び出しで完了する。
    */
   private async executeAgentLoop(
     session: Session,
@@ -354,8 +400,8 @@ export class LocalLlmRunner implements AgentRunner {
     abortController: AbortController,
     options?: RunOptions
   ): Promise<string> {
-    // chatモード: 1回のLLM呼び出しで完了（ツールなし）
-    if (this.chatMode) {
+    // liteモード: 1回のLLM呼び出しで完了（ツールなし）+ トリガー検出
+    if (this.liteMode) {
       let response;
       try {
         response = await this.llm.chat(session.messages, {
@@ -369,6 +415,34 @@ export class LocalLlmRunner implements AgentRunner {
         throw err;
       }
       session.messages.push({ role: 'assistant', content: response.content });
+
+      // トリガー検出・実行
+      const triggerResult = await this.processTriggers(response.content, channelId, sessionId);
+      if (triggerResult !== null) {
+        // feedback: true のトリガーなら結果をLLMに戻して再応答
+        const match = matchTrigger(response.content, this.triggers);
+        if (match?.trigger.feedback) {
+          session.messages.push({
+            role: 'user',
+            content: `[${match.trigger.name}の結果]\n${triggerResult}`,
+          });
+          let feedbackResponse;
+          try {
+            feedbackResponse = await this.llm.chat(session.messages, {
+              systemPrompt,
+              signal: abortController.signal,
+            });
+          } catch {
+            // feedbackのLLM呼び出し失敗時はtrigger結果をそのまま返す
+            return response.content + '\n\n' + triggerResult;
+          }
+          session.messages.push({ role: 'assistant', content: feedbackResponse.content });
+          return feedbackResponse.content;
+        }
+        // feedback: false — LLM応答 + trigger結果を返す
+        return response.content + '\n\n' + triggerResult;
+      }
+
       return response.content;
     }
 
@@ -450,7 +524,7 @@ export class LocalLlmRunner implements AgentRunner {
 
   /**
    * ストリーミングループ: ツール呼び出し + 最終応答ストリーミング
-   * chatモードではツールループをスキップし、直接ストリーミングで応答する。
+   * liteモードではツールループをスキップし、直接ストリーミングで応答する。
    */
   private async executeStreamLoop(
     session: Session,
@@ -462,8 +536,8 @@ export class LocalLlmRunner implements AgentRunner {
     callbacks: StreamCallbacks,
     options?: RunOptions
   ): Promise<string> {
-    // chatモードではツールループをスキップ
-    if (!this.chatMode) {
+    // liteモードではツールループをスキップ
+    if (!this.liteMode) {
       // ツールループ: non-streaming の chat() でツール呼び出しを処理
       let toolRounds = 0;
       while (toolRounds < MAX_TOOL_ROUNDS) {
@@ -583,8 +657,8 @@ export class LocalLlmRunner implements AgentRunner {
   private buildSystemPrompt(): string {
     const parts: string[] = [];
 
-    // chatモードではXANGI_COMMANDS・CHAT_SYSTEM_PROMPT・スキル一覧を除外
-    if (!this.chatMode) {
+    // liteモードではXANGI_COMMANDS・CHAT_SYSTEM_PROMPT・スキル一覧を除外
+    if (!this.liteMode) {
       parts.push(CHAT_SYSTEM_PROMPT_PERSISTENT + '\n\n## XANGI_COMMANDS.md\n\n' + XANGI_COMMANDS);
     }
 
@@ -592,8 +666,17 @@ export class LocalLlmRunner implements AgentRunner {
     const context = loadWorkspaceContext(this.workdir);
     if (context) parts.push(context);
 
+    // liteモードでトリガーが存在する場合、利用可能なコマンド一覧を追加（毎回リロード）
+    if (this.liteMode) {
+      this.triggers = loadTriggers(this.workdir);
+    }
+    if (this.liteMode && this.triggers.length > 0) {
+      const triggersPrompt = buildTriggersPrompt(this.triggers);
+      if (triggersPrompt) parts.push(triggersPrompt);
+    }
+
     // スキル一覧と使い方 — agentモードのみ
-    if (!this.chatMode) {
+    if (!this.liteMode) {
       const skills = loadSkills(this.workdir);
       if (skills.length > 0) {
         const skillLines = skills
@@ -648,6 +731,43 @@ export class LocalLlmRunner implements AgentRunner {
       const removed = session.messages.shift();
       if (removed) totalChars -= removed.content.length;
     }
+  }
+
+  /**
+   * LLM応答テキストからトリガーを検出・実行する。
+   * マッチしたら結果文字列を返す。マッチなしは null。
+   */
+  private async processTriggers(
+    text: string,
+    channelId: string,
+    sessionId: string
+  ): Promise<string | null> {
+    // 毎回trigger.yamlを読み直す（再起動なしで変更反映）
+    this.triggers = this.liteMode ? loadTriggers(this.workdir) : [];
+    if (this.triggers.length === 0) return null;
+
+    const match = matchTrigger(text, this.triggers);
+    if (!match) return null;
+
+    console.log(
+      `[local-llm] Trigger matched: ${match.trigger.trigger} (args: ${match.args || '(none)'})`
+    );
+
+    const result = await executeTrigger(match.trigger, match.args, this.workdir);
+    if (result.success) {
+      console.log(
+        `[local-llm] Trigger ${match.trigger.name} completed (${result.output.length} chars)`
+      );
+    } else {
+      logError(
+        this.workdir,
+        channelId,
+        `Trigger ${match.trigger.name} failed: ${result.output}`,
+        sessionId
+      );
+    }
+
+    return result.output;
   }
 
   private cleanupSessions(): void {

--- a/src/local-llm/triggers.ts
+++ b/src/local-llm/triggers.ts
@@ -1,0 +1,171 @@
+/**
+ * Triggers — chatモードでマジックワードによる機能発動
+ *
+ * ワークスペースの triggers/ ディレクトリから trigger.yaml を読み込み、
+ * LLM応答テキストからトリガーワードを検出して handler スクリプトを実行する。
+ */
+import { readFileSync, readdirSync, existsSync, statSync } from 'node:fs';
+import { join } from 'node:path';
+import { execFile } from 'node:child_process';
+import { parse as parseYaml } from 'yaml';
+
+const EXEC_TIMEOUT_MS = parseInt(process.env.EXEC_TIMEOUT_MS ?? '120000', 10);
+
+export interface Trigger {
+  name: string;
+  trigger: string;
+  description: string;
+  handler: string;
+  /** handler結果をLLMにフィードバックして再応答させるか（デフォルト: false） */
+  feedback: boolean;
+  /** trigger.yaml が存在するディレクトリの絶対パス */
+  path: string;
+}
+
+export interface TriggerMatch {
+  trigger: Trigger;
+  args: string;
+}
+
+/**
+ * ワークスペースの triggers/ ディレクトリをスキャンして trigger 定義を読み込む。
+ * triggers/ が存在しない場合は空配列を返す。
+ */
+export function loadTriggers(workdir: string): Trigger[] {
+  const triggersDir = join(workdir, 'triggers');
+  if (!existsSync(triggersDir) || !statSync(triggersDir).isDirectory()) {
+    return [];
+  }
+
+  const triggers: Trigger[] = [];
+  let entries: string[];
+  try {
+    entries = readdirSync(triggersDir);
+  } catch {
+    return [];
+  }
+
+  for (const entry of entries) {
+    const entryPath = join(triggersDir, entry);
+    if (!statSync(entryPath).isDirectory()) continue;
+
+    const yamlPath = join(entryPath, 'trigger.yaml');
+    if (!existsSync(yamlPath)) continue;
+
+    try {
+      const content = readFileSync(yamlPath, 'utf-8');
+      const parsed = parseYaml(content) as Record<string, unknown>;
+
+      if (!parsed.name || !parsed.trigger || !parsed.handler) {
+        console.warn(`[triggers] Invalid trigger.yaml in ${entry}: missing required fields`);
+        continue;
+      }
+
+      triggers.push({
+        name: String(parsed.name),
+        trigger: String(parsed.trigger),
+        description: String(parsed.description || ''),
+        handler: String(parsed.handler),
+        feedback: parsed.feedback === true,
+        path: entryPath,
+      });
+
+      console.log(`[triggers] Loaded: ${parsed.trigger} (${parsed.name})`);
+    } catch (err) {
+      console.warn(
+        `[triggers] Failed to parse ${yamlPath}: ${err instanceof Error ? err.message : String(err)}`
+      );
+    }
+  }
+
+  return triggers;
+}
+
+/**
+ * テキストからトリガーワードを検出する。
+ * `!weather 名古屋` のように、トリガーワードの後にスペース区切りで引数が続く形式。
+ * テキスト内の任意の行でマッチする。最初にマッチしたものを返す。
+ */
+export function matchTrigger(text: string, triggers: Trigger[]): TriggerMatch | null {
+  if (triggers.length === 0) return null;
+
+  for (const trigger of triggers) {
+    // 行ごとにチェック（全角！→半角!に正規化）
+    const lines = text.split('\n');
+    for (const line of lines) {
+      const trimmed = line.trim().replace(/！/g, '!');
+      // 完全一致
+      if (trimmed === trigger.trigger) {
+        return { trigger, args: '' };
+      }
+      // 行頭一致（引数あり）
+      if (trimmed.startsWith(trigger.trigger + ' ')) {
+        const args = trimmed.slice(trigger.trigger.length + 1).trim();
+        return { trigger, args };
+      }
+    }
+  }
+
+  return null;
+}
+
+/**
+ * トリガーの handler スクリプトを実行して結果を返す。
+ * handler はワークスペースルートを cwd として実行される。
+ */
+export function executeTrigger(
+  trigger: Trigger,
+  args: string,
+  workdir: string
+): Promise<{ success: boolean; output: string }> {
+  const handlerPath = join(trigger.path, trigger.handler);
+
+  return new Promise((resolve) => {
+    const argv = args ? args.split(/\s+/) : [];
+    execFile(
+      'bash',
+      [handlerPath, ...argv],
+      {
+        cwd: workdir,
+        timeout: EXEC_TIMEOUT_MS,
+        env: { ...process.env },
+      },
+      (error, stdout, stderr) => {
+        if (error) {
+          const errMsg = stderr || error.message;
+          console.error(`[triggers] Handler ${trigger.name} failed: ${errMsg}`);
+          resolve({ success: false, output: `Error: ${errMsg}` });
+        } else {
+          resolve({ success: true, output: stdout });
+        }
+      }
+    );
+  });
+}
+
+/**
+ * トリガー一覧をシステムプロンプト用のテキストに変換する。
+ */
+export function buildTriggersPrompt(triggers: Trigger[]): string {
+  if (triggers.length === 0) return '';
+
+  const lines = triggers.map((t) => `${t.trigger} — ${t.description}`);
+  return [
+    '## トリガーコマンド',
+    '',
+    'あなたの返答に以下のコマンドを含めると、システムが自動的に検出して実行します。',
+    '',
+    lines.join('\n'),
+    '',
+    '【重要ルール】',
+    '- ユーザーのリクエストに該当するコマンドがあれば、自分の知識で答えずにコマンドを使ってください',
+    '- コマンドは必ず行の先頭に単独で書いてください。他のテキストと同じ行に混ぜないでください',
+    '',
+    '良い例:',
+    'テックニュースを調べるね！',
+    '!technews',
+    '',
+    '悪い例:',
+    '!technews を使って調べるよ！',
+  ].join('\n');
+}

--- a/src/persistent-runner.ts
+++ b/src/persistent-runner.ts
@@ -6,6 +6,7 @@ import { DEFAULT_TIMEOUT_MS } from './constants.js';
 import { getSafeEnv } from './base-runner.js';
 import { buildPersistentSystemPrompt } from './base-runner.js';
 import type { ChatPlatform } from './prompts/index.js';
+import { getGitHubEnv } from './github-auth.js';
 import { logPrompt, logResponse, logError } from './transcript-logger.js';
 
 /**
@@ -120,7 +121,7 @@ export class PersistentRunner extends EventEmitter implements AgentRunner {
     this.process = spawn('claude', args, {
       stdio: ['pipe', 'pipe', 'pipe'],
       cwd: this.workdir,
-      env: getSafeEnv(),
+      env: { ...getSafeEnv(), ...getGitHubEnv(getSafeEnv()) },
     });
     this.processAlive = true;
 

--- a/tests/local-llm-runner.test.ts
+++ b/tests/local-llm-runner.test.ts
@@ -87,7 +87,7 @@ describe('formatLlmError', () => {
   });
 });
 
-describe('LocalLlmRunner chatMode', () => {
+describe('LocalLlmRunner liteMode', () => {
   const savedEnv: Record<string, string | undefined> = {};
   const envKeys = ['LOCAL_LLM_MODE', 'LOCAL_LLM_BASE_URL', 'LOCAL_LLM_MODEL'];
 
@@ -110,27 +110,27 @@ describe('LocalLlmRunner chatMode', () => {
     }
   });
 
-  it('should default to agent mode (chatMode=false)', () => {
+  it('should default to agent mode (liteMode=false)', () => {
     delete process.env.LOCAL_LLM_MODE;
     const runner = new LocalLlmRunner({ workdir: '/tmp', model: 'test' });
-    expect(runner.chatMode).toBe(false);
+    expect(runner.liteMode).toBe(false);
   });
 
-  it('should enable chatMode when LOCAL_LLM_MODE=chat', () => {
-    process.env.LOCAL_LLM_MODE = 'chat';
+  it('should enable liteMode when LOCAL_LLM_MODE=lite', () => {
+    process.env.LOCAL_LLM_MODE = 'lite';
     const runner = new LocalLlmRunner({ workdir: '/tmp', model: 'test' });
-    expect(runner.chatMode).toBe(true);
+    expect(runner.liteMode).toBe(true);
   });
 
   it('should stay in agent mode when LOCAL_LLM_MODE=agent', () => {
     process.env.LOCAL_LLM_MODE = 'agent';
     const runner = new LocalLlmRunner({ workdir: '/tmp', model: 'test' });
-    expect(runner.chatMode).toBe(false);
+    expect(runner.liteMode).toBe(false);
   });
 
   it('should be case-insensitive for LOCAL_LLM_MODE', () => {
-    process.env.LOCAL_LLM_MODE = 'Chat';
+    process.env.LOCAL_LLM_MODE = 'Lite';
     const runner = new LocalLlmRunner({ workdir: '/tmp', model: 'test' });
-    expect(runner.chatMode).toBe(true);
+    expect(runner.liteMode).toBe(true);
   });
 });

--- a/tests/triggers.test.ts
+++ b/tests/triggers.test.ts
@@ -1,0 +1,212 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdirSync, writeFileSync, rmSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { loadTriggers, matchTrigger, executeTrigger, buildTriggersPrompt } from '../src/local-llm/triggers.js';
+import type { Trigger } from '../src/local-llm/triggers.js';
+
+describe('triggers', () => {
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = join(tmpdir(), `xangi-triggers-test-${Date.now()}`);
+    mkdirSync(tmpDir, { recursive: true });
+  });
+
+  afterEach(() => {
+    rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  describe('loadTriggers', () => {
+    it('should return empty array when triggers/ does not exist', () => {
+      const triggers = loadTriggers(tmpDir);
+      expect(triggers).toEqual([]);
+    });
+
+    it('should load valid trigger definitions', () => {
+      const triggersDir = join(tmpDir, 'triggers', 'weather');
+      mkdirSync(triggersDir, { recursive: true });
+      writeFileSync(
+        join(triggersDir, 'trigger.yaml'),
+        'name: weather\ntrigger: "!weather"\ndescription: "天気を調べる"\nhandler: handler.sh\n'
+      );
+      writeFileSync(join(triggersDir, 'handler.sh'), 'echo "sunny"');
+
+      const triggers = loadTriggers(tmpDir);
+      expect(triggers).toHaveLength(1);
+      expect(triggers[0].name).toBe('weather');
+      expect(triggers[0].trigger).toBe('!weather');
+      expect(triggers[0].description).toBe('天気を調べる');
+      expect(triggers[0].handler).toBe('handler.sh');
+      expect(triggers[0].path).toBe(triggersDir);
+    });
+
+    it('should load multiple triggers', () => {
+      const weatherDir = join(tmpDir, 'triggers', 'weather');
+      const searchDir = join(tmpDir, 'triggers', 'search');
+      mkdirSync(weatherDir, { recursive: true });
+      mkdirSync(searchDir, { recursive: true });
+
+      writeFileSync(
+        join(weatherDir, 'trigger.yaml'),
+        'name: weather\ntrigger: "!weather"\ndescription: "天気を調べる"\nhandler: handler.sh\n'
+      );
+      writeFileSync(
+        join(searchDir, 'trigger.yaml'),
+        'name: search\ntrigger: "!search"\ndescription: "Web検索する"\nhandler: handler.sh\n'
+      );
+
+      const triggers = loadTriggers(tmpDir);
+      expect(triggers).toHaveLength(2);
+    });
+
+    it('should skip directories without trigger.yaml', () => {
+      const emptyDir = join(tmpDir, 'triggers', 'empty');
+      mkdirSync(emptyDir, { recursive: true });
+
+      const triggers = loadTriggers(tmpDir);
+      expect(triggers).toEqual([]);
+    });
+
+    it('should skip trigger.yaml with missing required fields', () => {
+      const badDir = join(tmpDir, 'triggers', 'bad');
+      mkdirSync(badDir, { recursive: true });
+      writeFileSync(join(badDir, 'trigger.yaml'), 'name: bad\n');
+
+      const triggers = loadTriggers(tmpDir);
+      expect(triggers).toEqual([]);
+    });
+  });
+
+  describe('matchTrigger', () => {
+    const triggers: Trigger[] = [
+      { name: 'weather', trigger: '!weather', description: '天気を調べる', handler: 'handler.sh', path: '/tmp/weather' },
+      { name: 'search', trigger: '!search', description: 'Web検索する', handler: 'handler.sh', path: '/tmp/search' },
+    ];
+
+    it('should match trigger without args', () => {
+      const result = matchTrigger('!weather', triggers);
+      expect(result).not.toBeNull();
+      expect(result!.trigger.name).toBe('weather');
+      expect(result!.args).toBe('');
+    });
+
+    it('should match trigger with args', () => {
+      const result = matchTrigger('!weather 名古屋', triggers);
+      expect(result).not.toBeNull();
+      expect(result!.trigger.name).toBe('weather');
+      expect(result!.args).toBe('名古屋');
+    });
+
+    it('should match trigger with multiple args', () => {
+      const result = matchTrigger('!search Claude Code 使い方', triggers);
+      expect(result).not.toBeNull();
+      expect(result!.trigger.name).toBe('search');
+      expect(result!.args).toBe('Claude Code 使い方');
+    });
+
+    it('should match trigger in multiline text', () => {
+      const text = '天気を調べますね。\n!weather 東京\nお待ちください。';
+      const result = matchTrigger(text, triggers);
+      expect(result).not.toBeNull();
+      expect(result!.trigger.name).toBe('weather');
+      expect(result!.args).toBe('東京');
+    });
+
+    it('should return null when no match', () => {
+      const result = matchTrigger('こんにちは', triggers);
+      expect(result).toBeNull();
+    });
+
+    it('should return null for empty triggers', () => {
+      const result = matchTrigger('!weather', []);
+      expect(result).toBeNull();
+    });
+
+    it('should not match partial trigger words', () => {
+      const result = matchTrigger('!weathering', triggers);
+      expect(result).toBeNull();
+    });
+
+    it('should match first trigger when multiple could match', () => {
+      const result = matchTrigger('!weather 東京\n!search test', triggers);
+      expect(result).not.toBeNull();
+      expect(result!.trigger.name).toBe('weather');
+    });
+  });
+
+  describe('executeTrigger', () => {
+    it('should execute handler and return stdout', async () => {
+      const triggerDir = join(tmpDir, 'test-trigger');
+      mkdirSync(triggerDir, { recursive: true });
+      writeFileSync(join(triggerDir, 'handler.sh'), '#!/bin/bash\necho "Hello $1"');
+
+      const trigger: Trigger = {
+        name: 'test',
+        trigger: '!test',
+        description: 'test',
+        handler: 'handler.sh',
+        path: triggerDir,
+      };
+
+      const result = await executeTrigger(trigger, 'World', tmpDir);
+      expect(result.success).toBe(true);
+      expect(result.output.trim()).toBe('Hello World');
+    });
+
+    it('should return error on script failure', async () => {
+      const triggerDir = join(tmpDir, 'fail-trigger');
+      mkdirSync(triggerDir, { recursive: true });
+      writeFileSync(join(triggerDir, 'handler.sh'), '#!/bin/bash\nexit 1');
+
+      const trigger: Trigger = {
+        name: 'fail',
+        trigger: '!fail',
+        description: 'fail',
+        handler: 'handler.sh',
+        path: triggerDir,
+      };
+
+      const result = await executeTrigger(trigger, '', tmpDir);
+      expect(result.success).toBe(false);
+    });
+
+    it('should handle empty args', async () => {
+      const triggerDir = join(tmpDir, 'noargs-trigger');
+      mkdirSync(triggerDir, { recursive: true });
+      writeFileSync(join(triggerDir, 'handler.sh'), '#!/bin/bash\necho "no args"');
+
+      const trigger: Trigger = {
+        name: 'noargs',
+        trigger: '!noargs',
+        description: 'no args',
+        handler: 'handler.sh',
+        path: triggerDir,
+      };
+
+      const result = await executeTrigger(trigger, '', tmpDir);
+      expect(result.success).toBe(true);
+      expect(result.output.trim()).toBe('no args');
+    });
+  });
+
+  describe('buildTriggersPrompt', () => {
+    it('should return empty string for empty triggers', () => {
+      expect(buildTriggersPrompt([])).toBe('');
+    });
+
+    it('should build prompt with trigger descriptions', () => {
+      const triggers: Trigger[] = [
+        { name: 'weather', trigger: '!weather', description: '天気を調べる', handler: 'handler.sh', path: '/tmp' },
+        { name: 'search', trigger: '!search', description: 'Web検索する', handler: 'handler.sh', path: '/tmp' },
+      ];
+
+      const prompt = buildTriggersPrompt(triggers);
+      expect(prompt).toContain('!weather');
+      expect(prompt).toContain('天気を調べる');
+      expect(prompt).toContain('!search');
+      expect(prompt).toContain('Web検索する');
+      expect(prompt).toContain('トリガーコマンド');
+    });
+  });
+});


### PR DESCRIPTION
## xangi v0.17.0

### 新機能
- **GitHub App認証**: `GITHUB_APP_ID` 等を設定すると `gh` CLI実行時にインストールトークンを自動生成。PAT不要、Python不要。ツール表示に `🔑App` バッジ。Docker対応
- **Triggers（liteモード拡張）**: liteモードでtools非対応モデルでも、LLMがマジックワード（`!コマンド名`）を出力するだけでスクリプトを実行。`triggers/` ディレクトリにYAML定義+シェルスクリプトを配置。`feedback: true` でhandler結果をLLMに戻して再応答も可能
- **liteモード**: `LOCAL_LLM_MODE=lite` で従来のchatモードを拡張。triggers対応

### 改善
- **Trigger表示**: liteモード応答時にトリガー実行結果の表示を改善

### ドキュメント
- GitHub App認証のセットアップ・Docker対応を usage.md に追加（日英）
- Triggers のセットアップ・YAML仕様・動作フローを usage.md に追加（日英）