### PR TITLE
fix: xangi-cmd のスケジュール参照先を WORKSPACE_PATH ベースに修正

### DIFF
--- a/src/cli/schedule-cmd.ts
+++ b/src/cli/schedule-cmd.ts
@@ -23,7 +23,8 @@ interface Schedule {
 }
 
 function getScheduleFilePath(): string {
-  const dataDir = process.env.DATA_DIR || join(process.cwd(), '.xangi');
+  const workdir = process.env.WORKSPACE_PATH || process.cwd();
+  const dataDir = join(workdir, '.xangi');
   if (!existsSync(dataDir)) {
     mkdirSync(dataDir, { recursive: true });
   }

--- a/src/cli/system-cmd.ts
+++ b/src/cli/system-cmd.ts
@@ -12,7 +12,8 @@ interface Settings {
 }
 
 function getSettingsFilePath(): string {
-  const dataDir = process.env.DATA_DIR || join(process.cwd(), '.xangi');
+  const workdir = process.env.WORKSPACE_PATH || process.cwd();
+  const dataDir = join(workdir, '.xangi');
   if (!existsSync(dataDir)) {
     mkdirSync(dataDir, { recursive: true });
   }
@@ -41,7 +42,8 @@ async function systemRestart(): Promise<string> {
   }
 
   // 再起動トリガーファイルを作成（xangiプロセスが監視して再起動）
-  const dataDir = process.env.DATA_DIR || join(process.cwd(), '.xangi');
+  const workdir = process.env.WORKSPACE_PATH || process.cwd();
+  const dataDir = join(workdir, '.xangi');
   writeFileSync(join(dataDir, 'restart-trigger'), Date.now().toString());
 
   return '🔄 再起動をリクエストしました';


### PR DESCRIPTION
## Summary
- `xangi-cmd schedule_list` が `process.cwd()` ベースで `schedules.json` を参照していたため、ワークスペースのスケジュールが見えず「スケジュールはありません」と返していた
- `WORKSPACE_PATH` 環境変数を使ってメインプロセスと同じパスを参照するように修正
- `system-cmd.ts` の設定ファイル参照・再起動トリガーも同様に修正

## 修正ファイル
- `src/cli/schedule-cmd.ts`: `getScheduleFilePath()` のパス解決を `WORKSPACE_PATH` ベースに変更
- `src/cli/system-cmd.ts`: `getSettingsFilePath()` と `systemRestart()` のパス解決を同様に変更

## Test plan
- [x] xangi-devで `xangi-cmd schedule_list` 実行し、登録済みスケジュール（25件）が正しく表示されることを確認
- [x] ビルド成功（修正ファイルにエラーなし）

Fixes #28

🤖 Generated with [Claude Code](https://claude.com/claude-code)