### PR TITLE
docs: add missing env vars to .env.example

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -33,6 +33,12 @@ DISCORD_TOKEN=your_discord_bot_token_here
 # Optional: Reply in channel instead of thread (default: true = thread)
 # SLACK_REPLY_IN_THREAD=false
 
+# Optional: Streaming output (default: true)
+# SLACK_STREAMING=true
+
+# Optional: Show thinking process (default: true)
+# SLACK_SHOW_THINKING=true
+
 # ========================================
 # 許可ユーザー設定
 # ========================================
@@ -126,6 +132,18 @@ DISCORD_ALLOWED_USER=your_discord_user_id_here
 
 # Optional: Skip permissions by default (true/false, default: false)
 # SKIP_PERMISSIONS=false
+
+# ========================================
+# プロセス管理設定
+# ========================================
+# Optional: Persistent process mode (default: true)
+# PERSISTENT_MODE=true
+
+# Optional: Maximum concurrent processes (default: 10)
+# MAX_PROCESSES=10
+
+# Optional: Auto-terminate idle processes after ms (default: 1800000 = 30min)
+# IDLE_TIMEOUT_MS=1800000
 
 # ========================================
 # GitHub App認証（オプション、設定するとgh CLIにAppトークンを自動注入）


### PR DESCRIPTION
## Summary
- `SLACK_STREAMING`, `SLACK_SHOW_THINKING` をSlack設定セクションに追加
- `PERSISTENT_MODE`, `MAX_PROCESSES`, `IDLE_TIMEOUT_MS` をプロセス管理セクションとして新設
- いずれも `src/config.ts` で既に使用されているが `.env.example` に記載漏れだった

## Test plan
- [ ] .env.example の記載がconfig.tsのデフォルト値と一致することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)