### PR TITLE
Release v0.22.1

### DIFF
--- a/bin/xangi-cmd
+++ b/bin/xangi-cmd
@@ -85,12 +85,14 @@ if [ -n "$_CHANNEL_ID" ]; then
 fi
 
 # tool-serverにリクエスト送信
-RESPONSE=$(curl -sf "$TOOL_SERVER/api/execute" \
+# -f は使わない: 4xx/5xx でも body を読めるようにする（サーバー側エラー詳細を表示するため）
+RESPONSE=$(curl -s "$TOOL_SERVER/api/execute" \
   -H 'Content-Type: application/json' \
   -d "{\"command\":\"$COMMAND\",\"flags\":$FLAGS,\"context\":$CONTEXT}" 2>&1)
 
 CURL_EXIT=$?
 
+# curl 自体が失敗した場合のみ「接続できません」を表示
 if [ $CURL_EXIT -ne 0 ]; then
   echo "Error: tool-server に接続できません ($TOOL_SERVER)" >&2
   echo "XANGI_TOOL_SERVER の値と xangiプロセスの起動状態を確認してください" >&2
@@ -99,11 +101,18 @@ fi
 
 # JSONレスポンスからresultを抽出（jqがあれば使う、なければそのまま出力）
 if command -v jq &>/dev/null; then
-  OK=$(echo "$RESPONSE" | jq -r '.ok // false')
+  OK=$(echo "$RESPONSE" | jq -r '.ok // false' 2>/dev/null)
   if [ "$OK" = "true" ]; then
     echo "$RESPONSE" | jq -r '.result'
   else
-    echo "$RESPONSE" | jq -r '.error // "Unknown error"' >&2
+    # サーバー側のエラーメッセージを表示（HTTP 4xx/5xx で返ってきたJSONも読める）
+    ERROR_MSG=$(echo "$RESPONSE" | jq -r '.error // empty' 2>/dev/null)
+    if [ -n "$ERROR_MSG" ]; then
+      echo "Error: $ERROR_MSG" >&2
+    else
+      # JSONとしてパースできない場合は生のレスポンスを出す
+      echo "Error: 予期しないレスポンス: $RESPONSE" >&2
+    fi
     exit 1
   fi
 else

--- a/src/cli/discord-api.ts
+++ b/src/cli/discord-api.ts
@@ -5,6 +5,8 @@
  * REST APIで直接Discord操作を行う。
  */
 
+import { ValidationError } from '../errors.js';
+
 const API_BASE = 'https://discord.com/api/v10';
 const MAX_MESSAGE_LENGTH = 2000;
 
@@ -73,7 +75,7 @@ function resolveHistoryChannelId(
   const currentChannelId = context?.channelId ?? process.env.XANGI_CHANNEL_ID;
   if (currentChannelId) return currentChannelId;
 
-  throw new Error(
+  throw new ValidationError(
     [
       'discord_history: channel が未指定です。',
       'xangi上で実行中なら現在のチャンネルIDを自動補完します。',
@@ -135,8 +137,8 @@ async function discordHistory(
 async function discordSend(flags: Record<string, string>): Promise<string> {
   const channelId = flags['channel'];
   const message = flags['message'];
-  if (!channelId) throw new Error('--channel is required');
-  if (!message) throw new Error('--message is required');
+  if (!channelId) throw new ValidationError('--channel is required');
+  if (!message) throw new ValidationError('--message is required');
 
   // 2000文字制限に合わせて分割送信
   const chunks: string[] = [];
@@ -159,7 +161,7 @@ async function discordSend(flags: Record<string, string>): Promise<string> {
 
 async function discordChannels(flags: Record<string, string>): Promise<string> {
   const guildId = flags['guild'];
-  if (!guildId) throw new Error('--guild is required');
+  if (!guildId) throw new ValidationError('--guild is required');
 
   const channels = (await discordFetch(`/guilds/${guildId}/channels`)) as DiscordChannel[];
 
@@ -175,8 +177,8 @@ async function discordChannels(flags: Record<string, string>): Promise<string> {
 async function discordSearch(flags: Record<string, string>): Promise<string> {
   const channelId = flags['channel'];
   const keyword = flags['keyword'];
-  if (!channelId) throw new Error('--channel is required');
-  if (!keyword) throw new Error('--keyword is required');
+  if (!channelId) throw new ValidationError('--channel is required');
+  if (!keyword) throw new ValidationError('--keyword is required');
 
   // Discord REST APIにはメッセージ検索がないため、最新100件を取得してフィルタ
   const messages = (await discordFetch(
@@ -206,9 +208,9 @@ async function discordEdit(flags: Record<string, string>): Promise<string> {
   const channelId = flags['channel'];
   const messageId = flags['message-id'];
   const content = flags['content'];
-  if (!channelId) throw new Error('--channel is required');
-  if (!messageId) throw new Error('--message-id is required');
-  if (!content) throw new Error('--content is required');
+  if (!channelId) throw new ValidationError('--channel is required');
+  if (!messageId) throw new ValidationError('--message-id is required');
+  if (!content) throw new ValidationError('--content is required');
 
   // 自分のメッセージか確認
   const botId = getBotId();
@@ -232,8 +234,8 @@ async function discordEdit(flags: Record<string, string>): Promise<string> {
 async function discordDelete(flags: Record<string, string>): Promise<string> {
   const channelId = flags['channel'];
   const messageId = flags['message-id'];
-  if (!channelId) throw new Error('--channel is required');
-  if (!messageId) throw new Error('--message-id is required');
+  if (!channelId) throw new ValidationError('--channel is required');
+  if (!messageId) throw new ValidationError('--message-id is required');
 
   // 自分のメッセージか確認
   const botId = getBotId();
@@ -256,14 +258,14 @@ async function discordDelete(flags: Record<string, string>): Promise<string> {
 async function mediaSend(flags: Record<string, string>): Promise<string> {
   const channelId = flags['channel'];
   const filePath = flags['file'];
-  if (!channelId) throw new Error('--channel is required');
-  if (!filePath) throw new Error('--file is required');
+  if (!channelId) throw new ValidationError('--channel is required');
+  if (!filePath) throw new ValidationError('--file is required');
 
   const { readFileSync, existsSync } = await import('fs');
   const { basename } = await import('path');
 
   if (!existsSync(filePath)) {
-    throw new Error(`File not found: ${filePath}`);
+    throw new ValidationError(`File not found: ${filePath}`);
   }
 
   const fileName = basename(filePath);
@@ -333,6 +335,6 @@ export async function discordApi(
     case 'media_send':
       return mediaSend(flags);
     default:
-      throw new Error(`Unknown discord command: ${command}`);
+      throw new ValidationError(`Unknown discord command: ${command}`);
   }
 }

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -1,0 +1,10 @@
+/**
+ * クライアント入力に起因するエラー（パラメータ不足・バリデーション失敗など）。
+ * tool-server側でこの型を投げると HTTP 400 で返る。それ以外は 500（サーバー内部エラー）。
+ */
+export class ValidationError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'ValidationError';
+  }
+}

--- a/src/gemini-cli.ts
+++ b/src/gemini-cli.ts
@@ -153,10 +153,14 @@ export class GeminiRunner implements AgentRunner {
   ): Promise<{ stdout: string; sessionId: string }> {
     const safeEnv = getSafeEnv();
     return new Promise((resolve, reject) => {
+      const childEnv: NodeJS.ProcessEnv = { ...safeEnv, ...getGitHubEnv(safeEnv) };
+      if (channelId) {
+        childEnv.XANGI_CHANNEL_ID = channelId;
+      }
       const proc = spawn('gemini', args, {
         stdio: ['ignore', 'pipe', 'pipe'],
         cwd: this.workdir,
-        env: { ...safeEnv, ...getGitHubEnv(safeEnv) },
+        env: childEnv,
       });
       this.currentProcess = proc;
 
@@ -276,10 +280,14 @@ export class GeminiRunner implements AgentRunner {
   ): Promise<RunResult> {
     const safeEnv = getSafeEnv();
     return new Promise((resolve, reject) => {
+      const childEnv: NodeJS.ProcessEnv = { ...safeEnv, ...getGitHubEnv(safeEnv) };
+      if (channelId) {
+        childEnv.XANGI_CHANNEL_ID = channelId;
+      }
       const proc = spawn('gemini', args, {
         stdio: ['ignore', 'pipe', 'pipe'],
         cwd: this.workdir,
-        env: { ...safeEnv, ...getGitHubEnv(safeEnv) },
+        env: childEnv,
       });
       this.currentProcess = proc;
 

--- a/src/persistent-runner.ts
+++ b/src/persistent-runner.ts
@@ -133,10 +133,15 @@ export class PersistentRunner extends EventEmitter implements AgentRunner {
 
     console.log('[persistent-runner] Starting persistent process...');
 
+    const safeEnv = getSafeEnv();
+    const childEnv: NodeJS.ProcessEnv = { ...safeEnv, ...getGitHubEnv(safeEnv) };
+    if (this.channelId) {
+      childEnv.XANGI_CHANNEL_ID = this.channelId;
+    }
     this.process = spawn('claude', args, {
       stdio: ['pipe', 'pipe', 'pipe'],
       cwd: this.workdir,
-      env: { ...getSafeEnv(), ...getGitHubEnv(getSafeEnv()) },
+      env: childEnv,
     });
     this.processAlive = true;
 

--- a/src/tool-server.ts
+++ b/src/tool-server.ts
@@ -13,6 +13,7 @@ import { discordApi } from './cli/discord-api.js';
 import { scheduleCmd } from './cli/schedule-cmd.js';
 import { systemCmd } from './cli/system-cmd.js';
 import { isGitHubAppEnabled, generateInstallationToken } from './github-auth.js';
+import { ValidationError } from './errors.js';
 
 let server: Server | null = null;
 
@@ -52,7 +53,7 @@ async function executeCommand(
   } else if (command.startsWith('system_')) {
     return systemCmd(command, flags);
   } else {
-    throw new Error(`Unknown command: ${command}`);
+    throw new ValidationError(`Unknown command: ${command}`);
   }
 }
 
@@ -112,8 +113,14 @@ export function startToolServer(): void {
         res.end(JSON.stringify({ ok: true, result }));
       } catch (err) {
         const message = err instanceof Error ? err.message : String(err);
-        console.error(`[tool-server] Error: ${message}`);
-        res.writeHead(500);
+        // ValidationError はクライアント入力の問題なので 400、それ以外は 500。
+        // name ベースで判定する（vitest 等で module が二重ロードされても安全）
+        const isValidation =
+          err instanceof ValidationError ||
+          (err instanceof Error && err.name === 'ValidationError');
+        const status = isValidation ? 400 : 500;
+        console.error(`[tool-server] Error (${status}): ${message}`);
+        res.writeHead(status);
         res.end(JSON.stringify({ ok: false, error: message }));
       }
       return;

--- a/tests/persistent-runner.test.ts
+++ b/tests/persistent-runner.test.ts
@@ -395,4 +395,54 @@ describe('PersistentRunner', () => {
       // ignore
     }
   });
+
+  // リグレッションテスト: PersistentRunner が channelId を XANGI_CHANNEL_ID として
+  // claude 子プロセスに注入することを検証。これが漏れると常駐セッション内から
+  // xangi-cmd を呼んだ時に context.channelId が空になり、tool-server で
+  // 「channel未指定」エラーが返って content-digest 等の投稿確認が失敗する。
+  it('should inject XANGI_CHANNEL_ID into spawned process when channelId is provided', async () => {
+    const { spawn } = await import('child_process');
+    (spawn as unknown as { mockClear: () => void }).mockClear();
+
+    const channelRunner = new PersistentRunner({
+      workdir: '/test/workdir',
+      skipPermissions: true,
+      channelId: 'test-channel-456',
+    });
+
+    // run() でプロセス起動をトリガー（レスポンスは待たない）
+    channelRunner.run('test prompt').catch(() => {
+      // shutdown によるエラーは無視
+    });
+
+    await new Promise((resolve) => setTimeout(resolve, 50));
+
+    expect(spawn).toHaveBeenCalled();
+    const callArgs = (spawn as unknown as { mock: { calls: unknown[][] } }).mock.calls[0];
+    const spawnOptions = callArgs[2] as { env: Record<string, string | undefined> };
+    expect(spawnOptions.env.XANGI_CHANNEL_ID).toBe('test-channel-456');
+
+    try {
+      channelRunner.shutdown();
+    } catch {
+      // ignore
+    }
+  });
+
+  it('should NOT inject XANGI_CHANNEL_ID when channelId is not provided', async () => {
+    const { spawn } = await import('child_process');
+    (spawn as unknown as { mockClear: () => void }).mockClear();
+
+    // 既定の runner は constructor に channelId なし
+    runner.run('test prompt').catch(() => {
+      // ignore
+    });
+
+    await new Promise((resolve) => setTimeout(resolve, 50));
+
+    expect(spawn).toHaveBeenCalled();
+    const callArgs = (spawn as unknown as { mock: { calls: unknown[][] } }).mock.calls[0];
+    const spawnOptions = callArgs[2] as { env: Record<string, string | undefined> };
+    expect(spawnOptions.env.XANGI_CHANNEL_ID).toBeUndefined();
+  });
 });

--- a/tests/schedule-cmd.test.ts
+++ b/tests/schedule-cmd.test.ts
@@ -1,0 +1,59 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdtempSync, rmSync, existsSync, mkdirSync } from 'fs';
+import { join } from 'path';
+import { tmpdir } from 'os';
+import { scheduleCmd } from '../src/cli/schedule-cmd.js';
+
+/**
+ * src/cli/schedule-cmd.ts のリグレッションテスト。
+ *
+ * PR #189: DATA_DIR が未設定でも WORKSPACE_PATH/.xangi に schedules.json
+ * を書き出すこと（process.cwd() に書かない）。
+ */
+describe('schedule-cmd WORKSPACE_PATH (PR #189)', () => {
+  let tmpDir: string;
+  let originalEnv: NodeJS.ProcessEnv;
+
+  beforeEach(() => {
+    tmpDir = mkdtempSync(join(tmpdir(), 'schedule-cmd-test-'));
+    originalEnv = { ...process.env };
+    delete process.env.DATA_DIR;
+    process.env.WORKSPACE_PATH = tmpDir;
+  });
+
+  afterEach(() => {
+    process.env = originalEnv;
+    rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it('writes schedules.json under WORKSPACE_PATH/.xangi when DATA_DIR is unset', async () => {
+    await scheduleCmd('schedule_add', {
+      input: '毎日 9:00 おはよう',
+      channel: 'ch1',
+      platform: 'discord',
+    });
+
+    const expectedPath = join(tmpDir, '.xangi', 'schedules.json');
+    expect(existsSync(expectedPath)).toBe(true);
+  });
+
+  it('respects DATA_DIR over WORKSPACE_PATH', async () => {
+    const dataDir = join(tmpDir, 'custom-data');
+    mkdirSync(dataDir, { recursive: true });
+    process.env.DATA_DIR = dataDir;
+
+    await scheduleCmd('schedule_add', {
+      input: '毎日 9:00 テスト',
+      channel: 'ch1',
+      platform: 'discord',
+    });
+
+    expect(existsSync(join(dataDir, 'schedules.json'))).toBe(true);
+    expect(existsSync(join(tmpDir, '.xangi', 'schedules.json'))).toBe(false);
+  });
+
+  it('returns empty list initially under fresh WORKSPACE_PATH', async () => {
+    const result = await scheduleCmd('schedule_list', {});
+    expect(result).toContain('スケジュールはありません');
+  });
+});

--- a/tests/system-cmd.test.ts
+++ b/tests/system-cmd.test.ts
@@ -1,0 +1,145 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdtempSync, rmSync, writeFileSync, readFileSync, existsSync, mkdirSync } from 'fs';
+import { join } from 'path';
+import { tmpdir } from 'os';
+import { spawn, type ChildProcess } from 'child_process';
+import { systemCmd } from '../src/cli/system-cmd.js';
+
+/**
+ * src/cli/system-cmd.ts のリグレッションテスト。
+ *
+ * - PR #199 (system_restart): PIDファイル方式の各分岐 + SIGTERM 送信
+ * - PR #189 (WORKSPACE_PATH): DATA_DIR 未設定時に WORKSPACE_PATH/.xangi を使う
+ *
+ * .xangi の場所と autoRestart デフォルトが退行しないことを保証する。
+ */
+describe('system-cmd', () => {
+  let tmpDir: string;
+  let originalEnv: NodeJS.ProcessEnv;
+  let spawnedProcs: ChildProcess[];
+
+  beforeEach(() => {
+    tmpDir = mkdtempSync(join(tmpdir(), 'system-cmd-test-'));
+    originalEnv = { ...process.env };
+    delete process.env.DATA_DIR;
+    process.env.WORKSPACE_PATH = tmpDir;
+    spawnedProcs = [];
+  });
+
+  afterEach(() => {
+    for (const p of spawnedProcs) {
+      try {
+        if (p.pid && !p.killed) p.kill('SIGKILL');
+      } catch {
+        // ignore
+      }
+    }
+    process.env = originalEnv;
+    rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  describe('system_settings (PR #189)', () => {
+    it('writes settings.json under WORKSPACE_PATH/.xangi when DATA_DIR is unset', async () => {
+      const result = await systemCmd('system_settings', { key: 'autoRestart', value: 'false' });
+      expect(result).toContain('autoRestart');
+
+      const expectedPath = join(tmpDir, '.xangi', 'settings.json');
+      expect(existsSync(expectedPath)).toBe(true);
+      const data = JSON.parse(readFileSync(expectedPath, 'utf-8'));
+      expect(data.autoRestart).toBe(false);
+    });
+
+    it('respects DATA_DIR over WORKSPACE_PATH', async () => {
+      const dataDir = join(tmpDir, 'custom-data');
+      mkdirSync(dataDir, { recursive: true });
+      process.env.DATA_DIR = dataDir;
+
+      await systemCmd('system_settings', { key: 'foo', value: 'bar' });
+
+      expect(existsSync(join(dataDir, 'settings.json'))).toBe(true);
+      // WORKSPACE_PATH/.xangi 側には書かれない
+      expect(existsSync(join(tmpDir, '.xangi', 'settings.json'))).toBe(false);
+    });
+
+    it('returns autoRestart=true by default when settings.json does not exist', async () => {
+      const result = await systemCmd('system_settings', {});
+      expect(result).toContain('autoRestart');
+      expect(result).toContain('true');
+    });
+  });
+
+  describe('system_restart (PR #199)', () => {
+    it('refuses when autoRestart is false', async () => {
+      // settings.json を autoRestart=false で先に作る
+      await systemCmd('system_settings', { key: 'autoRestart', value: 'false' });
+
+      const result = await systemCmd('system_restart', {});
+      expect(result).toContain('自動再起動が無効');
+    });
+
+    it('warns when PID file is missing', async () => {
+      // autoRestart デフォルト=true、PIDファイルなし
+      const result = await systemCmd('system_restart', {});
+      expect(result).toContain('PIDファイルが見つかりません');
+    });
+
+    it('warns when PID file content is invalid', async () => {
+      const dataDir = join(tmpDir, '.xangi');
+      mkdirSync(dataDir, { recursive: true });
+      writeFileSync(join(dataDir, 'xangi.pid'), 'not-a-number');
+
+      const result = await systemCmd('system_restart', {});
+      expect(result).toContain('内容が不正');
+    });
+
+    it('warns when PID points to a non-existent process (stale)', async () => {
+      const dataDir = join(tmpDir, '.xangi');
+      mkdirSync(dataDir, { recursive: true });
+      // ほぼ確実に存在しないPID（OSの上限近傍）
+      writeFileSync(join(dataDir, 'xangi.pid'), '99999999');
+
+      const result = await systemCmd('system_restart', {});
+      expect(result).toContain('プロセスが存在しません');
+    });
+
+    it('sends SIGTERM to the live process and returns success', async () => {
+      // SIGTERM ハンドラを持つ子プロセスを spawn
+      const child = spawn(
+        'node',
+        [
+          '-e',
+          `
+          process.on('SIGTERM', () => { process.exit(0); });
+          setInterval(() => {}, 1000);
+          `,
+        ],
+        { stdio: 'ignore' }
+      );
+      spawnedProcs.push(child);
+
+      // 起動を待つ
+      await new Promise<void>((resolve) => setTimeout(resolve, 100));
+      expect(child.pid).toBeGreaterThan(0);
+
+      // PIDファイルを書く
+      const dataDir = join(tmpDir, '.xangi');
+      mkdirSync(dataDir, { recursive: true });
+      writeFileSync(join(dataDir, 'xangi.pid'), String(child.pid));
+
+      // 子プロセスの exit を待つ Promise
+      const exited = new Promise<number | null>((resolve) => {
+        child.on('exit', (code) => resolve(code));
+      });
+
+      const result = await systemCmd('system_restart', {});
+      expect(result).toContain('再起動をリクエスト');
+
+      // SIGTERM で graceful shutdown → exit code 0
+      const exitCode = await Promise.race([
+        exited,
+        new Promise<number | null>((resolve) => setTimeout(() => resolve(-1), 2000)),
+      ]);
+      expect(exitCode).toBe(0);
+    });
+  });
+});

--- a/tests/tool-server.test.ts
+++ b/tests/tool-server.test.ts
@@ -1,0 +1,94 @@
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { startToolServer, stopToolServer } from '../src/tool-server.js';
+
+/**
+ * tool-server のステータスコード退行検出テスト。
+ *
+ * 過去にバリデーションエラー（クライアント入力ミス）も内部例外も
+ * 一律 HTTP 500 で返していた。今は ValidationError → 400、
+ * その他 → 500 の区別がある。これが退行しないことを保証する。
+ */
+describe('tool-server HTTP status codes', () => {
+  let serverUrl: string;
+
+  beforeAll(() => {
+    // 親シェルから引き継いだ XANGI_TOOL_SERVER を捨てる（実機xangiのURLを誤って叩かないため）
+    delete process.env.XANGI_TOOL_SERVER;
+    startToolServer();
+    // listen() コールバック内で XANGI_TOOL_SERVER が再設定される。それを待つ
+    return new Promise<void>((resolve) => {
+      const wait = () => {
+        if (process.env.XANGI_TOOL_SERVER) {
+          serverUrl = process.env.XANGI_TOOL_SERVER;
+          resolve();
+        } else {
+          setTimeout(wait, 10);
+        }
+      };
+      wait();
+    });
+  });
+
+  afterAll(() => {
+    stopToolServer();
+  });
+
+  it('returns 400 for ValidationError (channel未指定 in discord_history)', async () => {
+    const res = await fetch(`${serverUrl}/api/execute`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        command: 'discord_history',
+        flags: { count: '3' },
+        context: {}, // channelId 未指定
+      }),
+    });
+
+    expect(res.status).toBe(400);
+    const body = (await res.json()) as { ok: boolean; error: string };
+    expect(body.ok).toBe(false);
+    expect(body.error).toContain('channel が未指定');
+  });
+
+  it('returns 400 for unknown command', async () => {
+    const res = await fetch(`${serverUrl}/api/execute`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        command: 'discord_nonexistent',
+        flags: {},
+        context: {},
+      }),
+    });
+
+    expect(res.status).toBe(400);
+    const body = (await res.json()) as { ok: boolean; error: string };
+    expect(body.error).toContain('Unknown discord command');
+  });
+
+  it('returns 400 for missing required flag (discord_send without --message)', async () => {
+    const res = await fetch(`${serverUrl}/api/execute`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        command: 'discord_send',
+        flags: { channel: '12345' }, // message 欠如
+        context: {},
+      }),
+    });
+
+    expect(res.status).toBe(400);
+    const body = (await res.json()) as { ok: boolean; error: string };
+    expect(body.error).toContain('--message is required');
+  });
+
+  it('returns 400 when command is missing', async () => {
+    const res = await fetch(`${serverUrl}/api/execute`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ flags: {}, context: {} }),
+    });
+
+    expect(res.status).toBe(400);
+  });
+});

--- a/tests/xangi-cmd.test.ts
+++ b/tests/xangi-cmd.test.ts
@@ -1,0 +1,219 @@
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { createServer, type Server } from 'http';
+import { spawn } from 'child_process';
+import { join } from 'path';
+import { fileURLToPath } from 'url';
+import { dirname } from 'path';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const XANGI_CMD = join(__dirname, '..', 'bin', 'xangi-cmd');
+
+/**
+ * xangi-cmd CLI のリグレッションテスト。
+ *
+ * 過去に `curl -sf` で 4xx/5xx の body を捨てていたため、サーバー側の
+ * 意味のあるエラーメッセージ（例: 「channel が未指定」）が「接続できません」
+ * と誤訳されていた。それが退行しないことを保証する。
+ */
+
+interface MockResponse {
+  status: number;
+  body: string;
+}
+
+interface CapturedRequest {
+  command?: string;
+  flags?: Record<string, unknown>;
+  context?: Record<string, unknown>;
+}
+
+let mockServer: Server | null = null;
+let mockUrl = '';
+let mockResponse: MockResponse = { status: 200, body: '{"ok":true,"result":"default"}' };
+let lastRequest: CapturedRequest = {};
+
+function setMockResponse(res: MockResponse): void {
+  mockResponse = res;
+}
+
+function runCli(
+  args: string[],
+  env: Record<string, string> = {}
+): Promise<{ stdout: string; stderr: string; code: number }> {
+  return new Promise((resolve) => {
+    // env に明示的に空文字を渡すと「未設定」扱いにしたいので、空文字キーは削る
+    const baseEnv: Record<string, string> = { ...process.env } as Record<string, string>;
+    delete baseEnv.XANGI_CHANNEL_ID;
+    delete baseEnv.XANGI_DEFAULT_CHANNEL;
+    const finalEnv: Record<string, string> = {
+      ...baseEnv,
+      XANGI_TOOL_SERVER: mockUrl,
+    };
+    for (const [k, v] of Object.entries(env)) {
+      if (v === '') {
+        delete finalEnv[k];
+      } else {
+        finalEnv[k] = v;
+      }
+    }
+    const proc = spawn(XANGI_CMD, args, { env: finalEnv });
+    let stdout = '';
+    let stderr = '';
+    proc.stdout.on('data', (d) => {
+      stdout += d.toString();
+    });
+    proc.stderr.on('data', (d) => {
+      stderr += d.toString();
+    });
+    proc.on('close', (code) => {
+      resolve({ stdout, stderr, code: code ?? -1 });
+    });
+  });
+}
+
+// mockServer はファイル全体で共有（複数 describe 間で再利用）
+beforeAll(() => {
+  return new Promise<void>((resolve) => {
+    mockServer = createServer((req, res) => {
+      if (req.url === '/api/execute' && req.method === 'POST') {
+        let body = '';
+        req.on('data', (chunk) => {
+          body += chunk.toString();
+        });
+        req.on('end', () => {
+          try {
+            lastRequest = JSON.parse(body) as CapturedRequest;
+          } catch {
+            lastRequest = {};
+          }
+          res.statusCode = mockResponse.status;
+          res.setHeader('Content-Type', 'application/json');
+          res.end(mockResponse.body);
+        });
+      } else {
+        res.statusCode = 404;
+        res.end('{"error":"not found"}');
+      }
+    });
+    mockServer.listen(0, '127.0.0.1', () => {
+      const addr = mockServer!.address();
+      const port = typeof addr === 'object' && addr ? addr.port : 0;
+      mockUrl = `http://127.0.0.1:${port}`;
+      resolve();
+    });
+  });
+});
+
+afterAll(() => {
+  return new Promise<void>((resolve) => {
+    mockServer?.close(() => resolve());
+  });
+});
+
+describe('xangi-cmd CLI error handling', () => {
+  it('shows server error message when server returns HTTP 400 with .error', async () => {
+    setMockResponse({
+      status: 400,
+      body: JSON.stringify({
+        ok: false,
+        error: 'discord_history: channel が未指定です。',
+      }),
+    });
+
+    const { stderr, code } = await runCli(['discord_history']);
+
+    // 「接続できません」と誤訳されないこと（退行検出）
+    expect(stderr).not.toContain('接続できません');
+    // サーバー側のエラーメッセージが表示されること
+    expect(stderr).toContain('channel が未指定');
+    expect(code).not.toBe(0);
+  });
+
+  it('shows server error message when server returns HTTP 500 with .error', async () => {
+    setMockResponse({
+      status: 500,
+      body: JSON.stringify({
+        ok: false,
+        error: 'Internal server error: db connection refused',
+      }),
+    });
+
+    const { stderr, code } = await runCli(['discord_history']);
+
+    expect(stderr).not.toContain('接続できません');
+    expect(stderr).toContain('db connection refused');
+    expect(code).not.toBe(0);
+  });
+
+  it('outputs result on HTTP 200 success', async () => {
+    setMockResponse({
+      status: 200,
+      body: JSON.stringify({ ok: true, result: 'message history here' }),
+    });
+
+    const { stdout, code } = await runCli(['discord_history']);
+
+    expect(stdout).toContain('message history here');
+    expect(code).toBe(0);
+  });
+
+  it('reports connection error only when curl actually fails', async () => {
+    // 存在しないURLを指定 → curl が exit != 0
+    const { stderr, code } = await runCli(['discord_history'], {
+      XANGI_TOOL_SERVER: 'http://127.0.0.1:1', // 接続不能ポート
+    });
+
+    expect(stderr).toContain('接続できません');
+    expect(code).not.toBe(0);
+  });
+});
+
+/**
+ * PR #193 のリグレッションテスト。
+ *
+ * xangi-cmd CLI 単体実行時、`XANGI_CHANNEL_ID` が未設定だと
+ * 「現在のチャンネル」が補完されず、サーバー側で channel 未指定エラーに
+ * なっていた。`XANGI_DEFAULT_CHANNEL` をフォールバックとして拾うよう
+ * 修正された。`XANGI_CHANNEL_ID` 優先のフォールバック順が退行しないこと
+ * を保証する。
+ */
+describe('xangi-cmd CLI channelId completion', () => {
+  beforeAll(() => {
+    setMockResponse({
+      status: 200,
+      body: JSON.stringify({ ok: true, result: 'ok' }),
+    });
+  });
+
+  it('uses XANGI_CHANNEL_ID when set', async () => {
+    await runCli(['discord_history'], {
+      XANGI_CHANNEL_ID: '111',
+      XANGI_DEFAULT_CHANNEL: '',
+    });
+    expect(lastRequest.context).toEqual({ channelId: '111' });
+  });
+
+  it('falls back to XANGI_DEFAULT_CHANNEL when XANGI_CHANNEL_ID is unset', async () => {
+    await runCli(['discord_history'], {
+      XANGI_CHANNEL_ID: '',
+      XANGI_DEFAULT_CHANNEL: '222',
+    });
+    expect(lastRequest.context).toEqual({ channelId: '222' });
+  });
+
+  it('prefers XANGI_CHANNEL_ID over XANGI_DEFAULT_CHANNEL when both set', async () => {
+    await runCli(['discord_history'], {
+      XANGI_CHANNEL_ID: '111',
+      XANGI_DEFAULT_CHANNEL: '222',
+    });
+    expect(lastRequest.context).toEqual({ channelId: '111' });
+  });
+
+  it('sends empty context when neither env var is set', async () => {
+    await runCli(['discord_history'], {
+      XANGI_CHANNEL_ID: '',
+      XANGI_DEFAULT_CHANNEL: '',
+    });
+    expect(lastRequest.context).toEqual({});
+  });
+});


### PR DESCRIPTION
## xangi v0.22.1

### バグ修正
- **`xangi-cmd` エラーハンドリング3点修正**
  - **PersistentRunner で `XANGI_CHANNEL_ID` 注入漏れを修正**: 常駐セッション（content-digest 等）から `xangi-cmd discord_history` 等を実行すると `channel未指定` で失敗していた問題を解消。`claude-code.ts` 側では既に注入済みだったため、`persistent-runner.ts` / `gemini-cli.ts` も合わせて一貫させた
  - **CLI が `curl -sf` でサーバー側エラー詳細を握り潰していたのを修正**: `-f` を外し、HTTP エラー時もレスポンスJSON（`{"ok":false,"error":"..."}`）を読んで表示するように。これまで全部「tool-server に接続できません」と誤訳されていた問題を解消
  - **tool-server がバリデーションエラーも HTTP 500 で返していたのを修正**: `ValidationError` クラス（`src/errors.ts`）を新設し、クライアント入力ミスは 400、内部例外は 500 を返すように分離。監視・アラートの誤発火を回避

### テスト
- **xangi-cmd 系 fix PR のリグレッションテストを後追い追加**
  - 過去にマージ済の WORKSPACE_PATH 修正 / channelId補完 / system_restart 修正について、それぞれの修正が退行しないようテストを追加
  - `tests/xangi-cmd.test.ts` / `tests/system-cmd.test.ts` / `tests/schedule-cmd.test.ts` に計15ケース追加（全263テスト pass）
  - 教訓「fix PR には必ずリグレッションテストを入れる」を再確認するためのまとめ補強PR