### PR TITLE
Release v0.30.1

### DIFF
--- a/src/claude-code.ts
+++ b/src/claude-code.ts
@@ -2,6 +2,7 @@ import { spawn } from 'child_process';
 import { processManager } from './process-manager.js';
 import type { RunOptions, RunResult, StreamCallbacks } from './agent-runner.js';
 import { mergeTexts, sanitizeSurrogates, prependRuntimeContext } from './agent-runner.js';
+import { stripToolCallArtifacts, finalizeDisplayText } from './tool-call-sanitize.js';
 import { DEFAULT_TIMEOUT_MS } from './constants.js';
 import { getSafeEnv } from './base-runner.js';
 import { getGitHubEnv } from './github-auth.js';
@@ -98,7 +99,8 @@ export class ClaudeCodeRunner {
     }
 
     return {
-      result: response.result,
+      // 非ストリーミング経路でも tool-call 構文の除去 + 空→正直な fallback を適用
+      result: finalizeDisplayText(response.result),
       sessionId: response.session_id,
     };
   }
@@ -252,8 +254,11 @@ export class ClaudeCodeRunner {
             if (json.type === 'assistant' && json.message?.content) {
               for (const block of json.message.content) {
                 if (block.type === 'text') {
-                  fullText += block.text;
-                  callbacks.onText?.(block.text, fullText);
+                  const clean = stripToolCallArtifacts(block.text);
+                  if (clean) {
+                    fullText += clean;
+                    callbacks.onText?.(clean, fullText);
+                  }
                 }
               }
             } else if (json.type === 'result') {
@@ -267,7 +272,7 @@ export class ClaudeCodeRunner {
               // ストリーミング中の累積テキストと最終 result をマージ
               // （ツール呼び出し前のテキストが result から消えるのを防ぐ）
               if (json.result) {
-                fullText = mergeTexts(fullText, json.result);
+                fullText = mergeTexts(fullText, stripToolCallArtifacts(json.result));
               }
             }
           } catch {
@@ -297,14 +302,14 @@ export class ClaudeCodeRunner {
             if (json.type === 'assistant' && json.message?.content) {
               for (const block of json.message.content) {
                 if (block.type === 'text') {
-                  fullText += block.text;
+                  fullText += stripToolCallArtifacts(block.text);
                 }
               }
             } else if (json.type === 'result') {
               sessionId = json.session_id;
               // ストリーミング中の累積テキストと最終 result をマージ
               if (json.result) {
-                fullText = mergeTexts(fullText, json.result);
+                fullText = mergeTexts(fullText, stripToolCallArtifacts(json.result));
               }
             }
           } catch {
@@ -319,7 +324,7 @@ export class ClaudeCodeRunner {
           return;
         }
 
-        const result: RunResult = { result: fullText, sessionId };
+        const result: RunResult = { result: finalizeDisplayText(fullText), sessionId };
         callbacks.onComplete?.(result);
         resolve(result);
       });

--- a/src/file-utils.ts
+++ b/src/file-utils.ts
@@ -184,6 +184,75 @@ export function stripFilePaths(text: string): string {
 }
 
 /**
+ * 添付マーカー（MEDIA: / [IMAGE:|FILE:|VIDEO:|AUDIO:|MEDIA:]）が書かれているのに、
+ * 指す先が allowlist 内の実在ファイルでない（＝添付対象にならない）ものが残っているかを返す。
+ *
+ * Local LLM が generate.py 等を実行せず出力ファイル名だけ作文して `MEDIA:...` と書く
+ * 「捏造パス（phantom path）」を検出するための関数。markdown リンクと http(s)/data URL は
+ * 通常リンク・外部 URL であって添付失敗ではないので対象外。
+ */
+export function hasUnresolvedMediaMarker(text: string, workspaceRootOverride?: string): boolean {
+  if (!text) return false;
+  const workspaceRoot = getWorkspaceRoot(workspaceRootOverride);
+  const broadRoots = getBroadAllowedRoots(workspaceRoot);
+  const patterns = [/MEDIA:\s*([^\s\n]+)/g, /\[(?:IMAGE|FILE|VIDEO|AUDIO|MEDIA):\s*([^\]\n]+)\]/gi];
+  for (const pattern of patterns) {
+    pattern.lastIndex = 0;
+    let match: RegExpExecArray | null;
+    while ((match = pattern.exec(text)) !== null) {
+      const raw = match[1].trim();
+      // http(s)/data URL は添付対象外なので「生成失敗」ではない（誤検知を防ぐ）
+      if (/^(?:https?|data):/i.test(raw)) continue;
+      const resolved = resolveCandidate(raw, workspaceRoot);
+      if (!resolved) continue;
+      if (!realFileWithinRoots(resolved, broadRoots)) return true;
+    }
+  }
+  return false;
+}
+
+const DEFAULT_MISSING_MEDIA_NOTICE =
+  '⚠️ ファイル（画像など）を生成・添付できませんでした。生成に失敗した可能性があります。もう一度試してください。';
+
+/**
+ * 添付できなかったことをユーザに伝える注記。環境変数 `ATTACHMENT_MISSING_NOTICE` で上書き可能。
+ */
+export function getMissingMediaNotice(): string {
+  const custom = process.env.ATTACHMENT_MISSING_NOTICE?.trim();
+  return custom && custom.length > 0 ? custom : DEFAULT_MISSING_MEDIA_NOTICE;
+}
+
+/**
+ * 最終応答テキストから「添付するファイル群」と「表示用テキスト」を組み立てる共通ヘルパ。
+ * - テキスト由来パス（extractFilePaths）と構造化 attachments を合算・重複排除
+ * - 添付があればマーカーを除去した表示テキストを返す
+ * - 添付ゼロでも、実在しないメディアマーカー（捏造パス）が残っている場合は、
+ *   マーカーを除去したうえで生成失敗の注記を付け、ユーザが「描いたと言うのに何も出ない」
+ *   状態に陥らないようにする
+ */
+export function buildAttachmentResult(
+  result: string,
+  structuredAttachments?: string[],
+  workspaceRootOverride?: string
+): { filePaths: string[]; displayText: string } {
+  const filePaths = [
+    ...new Set([
+      ...extractFilePaths(result, workspaceRootOverride),
+      ...(structuredAttachments ?? []),
+    ]),
+  ];
+  if (filePaths.length > 0) {
+    return { filePaths, displayText: stripFilePaths(result) };
+  }
+  if (hasUnresolvedMediaMarker(result, workspaceRootOverride)) {
+    const stripped = stripFilePaths(result);
+    const notice = getMissingMediaNotice();
+    return { filePaths, displayText: stripped ? `${stripped}\n\n${notice}` : notice };
+  }
+  return { filePaths, displayText: result };
+}
+
+/**
  * 添付ファイル情報をプロンプトに追加
  */
 export function buildPromptWithAttachments(prompt: string, filePaths: string[]): string {

--- a/src/index.ts
+++ b/src/index.ts
@@ -23,12 +23,7 @@ import { ClaudeCodeRunner } from './claude-code.js';
 import { processManager } from './process-manager.js';
 import { loadSkills, formatSkillList, type Skill } from './skills.js';
 import { startSlackBot } from './slack.js';
-import {
-  downloadFile,
-  extractFilePaths,
-  stripFilePaths,
-  buildPromptWithAttachments,
-} from './file-utils.js';
+import { downloadFile, buildAttachmentResult, buildPromptWithAttachments } from './file-utils.js';
 import { initSettings, loadSettings, formatSettings } from './settings.js';
 import { updateEnvKeyValue } from './env-persist.js';
 import lockfile from 'proper-lockfile';
@@ -1083,11 +1078,11 @@ async function main() {
         setSession(channelId, runResult.sessionId);
 
         // ファイルパスを抽出して添付送信（テキスト由来 + 構造化 attachments を合算・重複排除）
-        const filePaths = [
-          ...new Set([...extractFilePaths(runResult.result), ...(runResult.attachments ?? [])]),
-        ];
-        const displayText =
-          filePaths.length > 0 ? stripFilePaths(runResult.result) : runResult.result;
+        // 添付ゼロでも実在しない MEDIA マーカーが残る場合は生成失敗の注記に差し替える
+        const { filePaths, displayText } = buildAttachmentResult(
+          runResult.result,
+          runResult.attachments
+        );
 
         const chunks = splitMessage(displayText, DISCORD_SAFE_LENGTH);
         await interaction.editReply(chunks[0] || '✅');
@@ -1681,8 +1676,7 @@ async function main() {
         setSession(channelId, newSessionId, 'scheduler');
 
         // 結果を送信（テキスト由来 + 構造化 attachments を合算・重複排除）
-        const filePaths = [...new Set([...extractFilePaths(result), ...(attachments ?? [])])];
-        const displayText = filePaths.length > 0 ? stripFilePaths(result) : result;
+        const { filePaths, displayText } = buildAttachmentResult(result, attachments);
 
         // === セパレータで明示的に分割（content-digest等で複数投稿を1応答に含める用途）
         // LLMが前後に空白や余分な改行を入れることがあるため、正規表現で緩くマッチ
@@ -2105,8 +2099,7 @@ async function processPrompt(
     );
 
     // ファイルパスを抽出して添付送信（テキスト由来 + 構造化 attachments を合算・重複排除）
-    const filePaths = [...new Set([...extractFilePaths(result), ...(structuredAttachments ?? [])])];
-    const displayText = filePaths.length > 0 ? stripFilePaths(result) : result;
+    const { filePaths, displayText } = buildAttachmentResult(result, structuredAttachments);
 
     // === セパレータで明示的に分割（content-digest等で複数投稿を1応答に含める用途）
     // LLMが前後に空白や余分な改行を入れることがあるため、正規表現で緩くマッチ

--- a/src/local-llm/pseudo-toolcall.ts
+++ b/src/local-llm/pseudo-toolcall.ts
@@ -54,16 +54,24 @@ export function containsPseudoToolCall(text: string): boolean {
 }
 
 /**
+ * Strict drift + cosmetic leak を除去する（trim はしない素の core）。
+ * 汎用サニタイザ（tool-call-sanitize.ts）から他ファミリと合成するために公開する。
+ */
+export function applyPseudoToolCallStrip(text: string): string {
+  let result = text;
+  for (const pattern of [...STRICT_DRIFT_PATTERNS, ...COSMETIC_LEAK_PATTERNS]) {
+    result = result.replace(pattern, '');
+  }
+  return result;
+}
+
+/**
  * Strict drift + cosmetic leak を全部除去して trim する。
  * containsPseudoToolCall が false でも cosmetic leak は残ってる可能性があるので、
  * 最終出力の整形には常にこの関数を通す。
  */
 export function stripPseudoToolCalls(text: string): string {
-  let result = text;
-  for (const pattern of [...STRICT_DRIFT_PATTERNS, ...COSMETIC_LEAK_PATTERNS]) {
-    result = result.replace(pattern, '');
-  }
-  return result.trim();
+  return applyPseudoToolCallStrip(text).trim();
 }
 
 /** drift 検出時に LLM に返すフィードバック system message */

--- a/src/local-llm/runner.ts
+++ b/src/local-llm/runner.ts
@@ -39,13 +39,13 @@ import { getAllXangiTools } from './xangi-tools.js';
 import { prependRuntimeContext } from '../runtime-context.js';
 import {
   containsPseudoToolCall,
-  stripPseudoToolCalls,
   parsePseudoToolCall,
   isSafeForRescue,
   buildStructuredFeedback,
   StreamingDriftBuffer,
   FRIENDLY_FALLBACK_MESSAGE,
 } from './pseudo-toolcall.js';
+import { stripToolCallArtifacts } from '../tool-call-sanitize.js';
 import {
   ToolTrajectoryLogger,
   loggerOptionsFromEnv,
@@ -1216,7 +1216,9 @@ export class LocalLlmRunner extends EventEmitter implements AgentRunner {
       }
       session.messages.push({ role: 'assistant', content: response.content });
 
-      return response.content;
+      // 非ストリーミング経路でも drift strip を適用する（executeStreamLoop と対称）。
+      // lite モードでも擬似テキスト (`<|channel>thought<channel|>` 等) が漏れうるため。
+      return this.finalizeNonStreamContent(response.content);
     }
 
     let toolRounds = 0;
@@ -1399,12 +1401,38 @@ export class LocalLlmRunner extends EventEmitter implements AgentRunner {
       }
     }
 
+    // drift strip を MEDIA 追記の前に適用する（executeStreamLoop と同じ順序）。
+    // scheduler / slash command 経路はこの非ストリーミングループを通るため、ここで
+    // strip しないと `<|channel>thought<channel|>` 等の擬似テキストが Discord に漏れる。
+    finalContent = this.finalizeNonStreamContent(finalContent);
+
     // ツール結果から検出したMEDIA:パスを最終応答に追記
     if (pendingMediaPaths.length > 0) {
       finalContent += '\n' + pendingMediaPaths.map((p) => `MEDIA:${p}`).join('\n');
     }
 
     return finalContent;
+  }
+
+  /**
+   * 非ストリーミング経路の最終応答を整形する。
+   * executeStreamLoop の最終 fallback（drift strip + 空 fallback）と対称の責務。
+   * 非ストリーミング経路には rescue/retry 機構が無いため strip + 空 fallback のみ。
+   *
+   * - 実応答 + drift が混在 → drift だけ strip して実応答を残す
+   * - 出力が drift だけ（strip 後が空）→ 誤解を招く空応答（Discord の `✅` fallback）
+   *   ではなく正直な fallback メッセージを返す
+   * - 元から空（ツールだけ実行して本文無し等）→ 空のまま（既存挙動を保つ）
+   */
+  private finalizeNonStreamContent(text: string): string {
+    const cleaned = stripToolCallArtifacts(text, { trim: true });
+    if (!cleaned && text.trim()) {
+      console.warn(
+        `[local-llm] Output was drift-only in non-stream loop, replaced with fallback. Raw head: ${text.slice(0, 200)}`
+      );
+      return FRIENDLY_FALLBACK_MESSAGE;
+    }
+    return cleaned;
   }
 
   /**
@@ -1612,6 +1640,12 @@ export class LocalLlmRunner extends EventEmitter implements AgentRunner {
     //   - system に FEEDBACK_PROMPT を積む (どう修正すべきかを LLM に伝える)
     //   - chatStream を 1 回だけ再実行
     // Step D: retry でも drift しか出なければ親切な fallback メッセージに差し替える。
+    // 直近の finalChatStreamOnce() が drift を drop したか。
+    // hold buffer が strict drift を stream 途中で drop すると fullText からは drift が
+    // 消えて containsPseudoToolCall が false になるため、別途このフラグで「drift があった」
+    // ことを下流の rescue ループ / 最終 fallback に伝える（drift-only → 空 → 誤 ✅ を防ぐ）。
+    let lastStreamDroppedDrift = false;
+
     const finalChatStreamOnce = async (): Promise<string> => {
       let acc = '';
       // hold buffer: streaming 中の擬似 tool_call drift を Discord に流す前に検出 + 抑止。
@@ -1657,6 +1691,7 @@ export class LocalLlmRunner extends EventEmitter implements AgentRunner {
           },
         });
       }
+      lastStreamDroppedDrift = totalDroppedDuringStream || droppedAny;
       return acc;
     };
 
@@ -1681,13 +1716,48 @@ export class LocalLlmRunner extends EventEmitter implements AgentRunner {
     };
     let driftRetryCount = 0;
 
-    while (containsPseudoToolCall(fullText) && driftRetryCount < MAX_DRIFT_RESCUE_RETRIES) {
+    while (
+      (containsPseudoToolCall(fullText) || (lastStreamDroppedDrift && !fullText.trim())) &&
+      driftRetryCount < MAX_DRIFT_RESCUE_RETRIES
+    ) {
+      const trajCommonDrift = this.trajectoryCommon(logId, options?.channelId, driftRetryCount);
+
+      // stream 中に strict drift が全部 drop されて本文が空になったケース。
+      // fullText に解析対象が残っていないので、plain text 再生成を明示的に促す。
+      // （例: ツールで情報収集後、最終応答が `<|channel>thought<channel|>` 等の擬似テキスト
+      //   だけ → hold buffer が drop → 本文が空 → 空応答が誤った成功マークになる事象を防ぐ）
+      if (!fullText.trim()) {
+        console.warn(
+          `[local-llm] Streamed response was drift-only (dropped to empty), requesting plain-text regeneration (retry ${driftRetryCount + 1}/${MAX_DRIFT_RESCUE_RETRIES}).`
+        );
+        this.trajectoryLogger.logDriftRescue(trajCommonDrift, {
+          raw_text_head: '(dropped during streaming)',
+          safety_verdict: 'dropped_empty',
+          executed: false,
+          failure_reason: 'stream drift dropped to empty',
+        });
+        session.messages.push({
+          role: 'system',
+          content: buildStructuredFeedback({
+            kind: 'unparseable_pseudo_call',
+            reason:
+              'Your previous response was discarded because it consisted only of reasoning/channel markers (e.g. <|channel>thought<channel|>) with no user-facing text.',
+            hint: 'Answer the user directly in plain Japanese text. Do NOT emit <|channel>, thought, or call: markers. Use the tool results already gathered in this conversation.',
+            allowed_actions: [
+              'Respond to the user in plain text using the information already gathered',
+            ],
+          }),
+        });
+        driftRetryCount++;
+        fullText = await finalChatStreamOnce();
+        continue;
+      }
+
       console.warn(
         `[local-llm] Pseudo tool_call drift detected (retry ${driftRetryCount + 1}/${MAX_DRIFT_RESCUE_RETRIES}). Raw head: ${fullText.slice(0, 200)}`
       );
 
       const parsed = parsePseudoToolCall(fullText);
-      const trajCommonDrift = this.trajectoryCommon(logId, options?.channelId, driftRetryCount);
 
       // assistant に raw drift を必ず積む (LLM が「自分が何を吐いたか」を見られるように)
       session.messages.push({ role: 'assistant', content: fullText });
@@ -1857,15 +1927,22 @@ export class LocalLlmRunner extends EventEmitter implements AgentRunner {
 
     // 最終 fallback: bounded retry 上限を超えても drift が残る → strip + 親切な fallback
     if (containsPseudoToolCall(fullText)) {
-      const cleaned = stripPseudoToolCalls(fullText);
+      const cleaned = stripToolCallArtifacts(fullText, { trim: true });
       console.warn(
         `[local-llm] Drift persisted after ${MAX_DRIFT_RESCUE_RETRIES} rescue retries. Raw head: ${fullText.slice(0, 200)}, cleaned: "${cleaned.slice(0, 100)}"`
       );
       fullText = cleaned || FRIENDLY_FALLBACK_MESSAGE;
     } else {
       // strict drift は無いが cosmetic leak (先頭/末尾の bare `thought\n` 等) は除去する。
-      // stripPseudoToolCalls は strict + cosmetic 両方除去する idempotent な関数。
-      fullText = stripPseudoToolCalls(fullText);
+      // stripToolCallArtifacts は strict + cosmetic + Anthropic 形式を除去する idempotent な関数。
+      const cleaned = stripToolCallArtifacts(fullText, { trim: true });
+      // cosmetic leak だけで本文が無かった、または stream 中に strict drift が drop されて
+      // 本文が空のまま残った場合、strip 結果も空になる。空のまま返すと Discord 層の
+      // `|| '✅'` fallback で誤解を招く成功マークになるため、正直な fallback に差し替える。
+      // （元から空 = ツールのみ実行で本文なし、drift も無し、のケースは空のまま維持して
+      //   既存挙動を壊さない）
+      fullText =
+        cleaned || (fullText.trim() || lastStreamDroppedDrift ? FRIENDLY_FALLBACK_MESSAGE : '');
     }
 
     // ツール結果から検出したMEDIA:パスを最終応答に追記

--- a/src/persistent-runner.ts
+++ b/src/persistent-runner.ts
@@ -9,6 +9,7 @@ import type {
   ExtendTimeoutResult,
 } from './agent-runner.js';
 import { mergeTexts, sanitizeSurrogates, prependRuntimeContext } from './agent-runner.js';
+import { stripToolCallArtifacts, finalizeDisplayText } from './tool-call-sanitize.js';
 import { DEFAULT_TIMEOUT_MS, MAX_TIMEOUT_MS, TIMEOUT_EXTEND_ENABLED } from './constants.js';
 import { getSafeEnv } from './base-runner.js';
 import { buildPersistentSystemPrompt } from './base-runner.js';
@@ -290,8 +291,11 @@ export class PersistentRunner extends EventEmitter implements AgentRunner {
     if (json.type === 'assistant' && json.message?.content) {
       for (const block of json.message.content) {
         if (block.type === 'text' && block.text) {
-          this.fullText += block.text;
-          this.currentItem?.callbacks?.onText?.(block.text, this.fullText);
+          const clean = stripToolCallArtifacts(block.text);
+          if (clean) {
+            this.fullText += clean;
+            this.currentItem?.callbacks?.onText?.(clean, this.fullText);
+          }
         }
         if (block.type === 'tool_use' && block.name) {
           this.currentItem?.callbacks?.onToolUse?.(block.name, block.input ?? {});
@@ -364,11 +368,13 @@ export class PersistentRunner extends EventEmitter implements AgentRunner {
         // ストリーミング中の累積テキストと最終 result をマージ
         // （ツール呼び出し前のテキストが result から消えるのを防ぐ）
         if (json.result) {
-          this.fullText = mergeTexts(this.fullText, json.result);
+          this.fullText = mergeTexts(this.fullText, stripToolCallArtifacts(json.result));
         }
 
         const result: RunResult = {
-          result: this.fullText,
+          // 本文が空（strip 後に空 / モデルが本文を出さず end_turn）の場合は
+          // 誤解を招く `✅` ではなく正直な fallback を返す
+          result: finalizeDisplayText(this.fullText),
           sessionId: this.sessionId,
         };
 

--- a/src/slack.ts
+++ b/src/slack.ts
@@ -5,12 +5,7 @@ import type { AgentRunner, RunResult } from './agent-runner.js';
 import { processManager } from './process-manager.js';
 import type { Skill } from './skills.js';
 import { formatSkillList } from './skills.js';
-import {
-  downloadFile,
-  extractFilePaths,
-  stripFilePaths,
-  buildPromptWithAttachments,
-} from './file-utils.js';
+import { downloadFile, buildAttachmentResult, buildPromptWithAttachments } from './file-utils.js';
 import { loadSettings, formatSettings } from './settings.js';
 import { STREAM_UPDATE_INTERVAL_MS, TIMEOUT_EXTEND_ENABLED } from './constants.js';
 import { threadIdFor, turnIdFor } from './events-emitter.js';
@@ -1082,8 +1077,7 @@ async function processMessage(
     console.log(`[slack] Final result length: ${result.length}`);
 
     // ファイルパスを抽出して添付送信（テキスト由来 + 構造化 attachments を合算・重複排除）
-    const filePaths = [...new Set([...extractFilePaths(result), ...(structuredAttachments ?? [])])];
-    const displayText = filePaths.length > 0 ? stripFilePaths(result) : result;
+    const { filePaths, displayText } = buildAttachmentResult(result, structuredAttachments);
 
     // 最終結果を更新（長い場合は分割送信）
     await sendSlackResult(client, channelId, messageTs, threadTs, displayText || '✅');

--- a/src/tool-call-sanitize.ts
+++ b/src/tool-call-sanitize.ts
@@ -1,0 +1,86 @@
+// 表示テキストに漏れた「ツールコール構文」を除去する汎用サニタイザ。
+//
+// バックエンド（Claude / Local LLM）に関わらず、LLM はまれに構造化された
+// tool 呼び出しではなく、ツールコール構文を **そのままテキストとして** 吐く
+// ことがある。中継 UI（Discord / Slack / Web）に生の構文が届くのを防ぐため、
+// 表示境界でこの 1 関数を通す。バックエンドごとの個別パッチを増やさず、
+// 「ユーザーに生のツールコール構文を見せない」という単一の不変条件に集約する。
+//
+// 対応する構文ファミリ:
+// - Anthropic / Claude 形式: `call\n<invoke name="...">...<parameter ...>...</invoke>`
+//   `<function_calls>...</function_calls>`（`antml:` prefix 付き含む）
+// - Local LLM / Gemma・Harmony 形式: `<|tool_call>call:fn{args}<tool_call|>`、
+//   `<|channel>thought...<channel|>`、bare `call:fn{args}` 等
+//   （後者の実パターンは local-llm/pseudo-toolcall.ts が一次定義し、ここから委譲）
+
+import {
+  applyPseudoToolCallStrip,
+  FRIENDLY_FALLBACK_MESSAGE,
+} from './local-llm/pseudo-toolcall.js';
+
+/** Anthropic（Claude）形式のツールコール XML を除去する（trim はしない） */
+function stripAnthropicToolCallXml(text: string): string {
+  if (!/<(?:antml:)?(?:invoke|function_calls)\b/i.test(text)) {
+    return text;
+  }
+  let t = text;
+  // ツールコールブロック直前の単独 `call` 行を、ブロックごと巻き込んで消す
+  t = t.replace(
+    /(?:^|\n)[ \t]*call[ \t]*(?=\n[ \t]*<(?:antml:)?(?:invoke|function_calls)\b)/gi,
+    '\n'
+  );
+  // <function_calls>...</function_calls>
+  t = t.replace(/<(?:antml:)?function_calls\b[\s\S]*?<\/(?:antml:)?function_calls>/gi, '');
+  // <invoke ...>...</invoke>
+  t = t.replace(/<(?:antml:)?invoke\b[\s\S]*?<\/(?:antml:)?invoke>/gi, '');
+  // 孤立した <parameter ...>...</parameter>
+  t = t.replace(/<(?:antml:)?parameter\b[\s\S]*?<\/(?:antml:)?parameter>/gi, '');
+  // 閉じタグが無いまま末尾まで続く開きタグ（ストリーム途中切断の保険）
+  t = t.replace(/<(?:antml:)?(?:invoke|function_calls)\b[\s\S]*$/gi, '');
+  return t;
+}
+
+export interface SanitizeOptions {
+  /** 前後の空白を trim するか（最終表示は true、ストリーミング途中の連結は false 推奨） */
+  trim?: boolean;
+}
+
+/**
+ * 全ファミリのツールコール構文を表示テキストから除去する汎用サニタイザ。
+ *
+ * - Anthropic 形式と Local LLM 形式の両方を順に除去
+ * - 除去後に空白のみ残るブロックは空文字に倒す（バブル蓄積で余計な空行が
+ *   前置されるのを防ぐ）
+ * - `trim: true` で最終表示向けに前後空白も落とす
+ */
+export function stripToolCallArtifacts(text: string, opts: SanitizeOptions = {}): string {
+  if (!text) return text;
+  let t = stripAnthropicToolCallXml(text);
+  t = applyPseudoToolCallStrip(t);
+  // 除去で生じた 3 連以上の空行を畳む
+  t = t.replace(/\n{3,}/g, '\n\n');
+  if (opts.trim) t = t.trim();
+  // ツールコール構文だけのブロックは中身が空白のみになる → 空文字に倒す
+  if (t.trim() === '') return '';
+  return t;
+}
+
+/**
+ * 最終表示テキストを確定する汎用ヘルパ。
+ *
+ * tool-call 構文を除去（trim 付き）した上で、結果が空になった場合は
+ * 誤解を招く成功マーク（Discord/Slack の `|| '✅'` fallback）ではなく
+ * 正直な fallback メッセージを返す。
+ *
+ * 空になる経路は 2 つあり、どちらも「✅」を出すべきでない:
+ * - 出力が tool-call 構文だけで、strip した結果が空（drift / XML 漏れの裏返し）
+ * - モデルが本文テキストを 1 文字も出さずにターンを終えた
+ *   （例: 拡張思考だけで end_turn、`result: ""` + `output_tokens > 0`）
+ *
+ * Claude 経路・Local LLM 経路のどちらの最終 result にも通せる
+ * （strip は idempotent なので二重適用しても安全）。
+ */
+export function finalizeDisplayText(text: string | undefined | null): string {
+  const clean = stripToolCallArtifacts(text ?? '', { trim: true });
+  return clean || FRIENDLY_FALLBACK_MESSAGE;
+}

--- a/src/tool-trajectory/logger.ts
+++ b/src/tool-trajectory/logger.ts
@@ -88,7 +88,8 @@ export type DriftSafetyVerdict =
   | 'unsafe'
   | 'unparseable'
   | 'already_executed'
-  | 'loop_blocked';
+  | 'loop_blocked'
+  | 'dropped_empty';
 
 export interface DriftRescuePayload {
   raw_text_head: string;

--- a/tests/file-utils.test.ts
+++ b/tests/file-utils.test.ts
@@ -7,6 +7,9 @@ import {
   stripFilePaths,
   buildPromptWithAttachments,
   resolveAttachmentPath,
+  hasUnresolvedMediaMarker,
+  buildAttachmentResult,
+  getMissingMediaNotice,
 } from '../src/file-utils.js';
 
 describe('extractFilePaths', () => {
@@ -218,5 +221,132 @@ describe('buildPromptWithAttachments', () => {
     expect(buildPromptWithAttachments('hi', ['/a/b.png'])).toBe(
       'hi\n\n[添付ファイル]\n  - /a/b.png'
     );
+  });
+});
+
+describe('hasUnresolvedMediaMarker', () => {
+  let workspace: string;
+  let outputsDir: string;
+  let imageRel: string;
+  let imageAbs: string;
+
+  beforeEach(() => {
+    workspace = mkdtempSync(join(tmpdir(), 'xangi-ws-'));
+    outputsDir = join(workspace, 'outputs');
+    mkdirSync(outputsDir, { recursive: true });
+    imageAbs = join(outputsDir, 'real.png');
+    imageRel = 'outputs/real.png';
+    writeFileSync(imageAbs, 'fakepng');
+  });
+
+  afterEach(() => {
+    rmSync(workspace, { recursive: true, force: true });
+  });
+
+  it('returns true when a MEDIA: path does not exist (the phantom-path bug)', () => {
+    const text = `描いたよ！\nMEDIA:outputs/phantom.png`;
+    expect(hasUnresolvedMediaMarker(text, workspace)).toBe(true);
+  });
+
+  it('returns true when an [IMAGE:...] path does not exist', () => {
+    const text = `完成！[IMAGE:outputs/phantom.png]`;
+    expect(hasUnresolvedMediaMarker(text, workspace)).toBe(true);
+  });
+
+  it('returns false when the MEDIA: path is a real file', () => {
+    const text = `できたよ MEDIA:${imageRel}`;
+    expect(hasUnresolvedMediaMarker(text, workspace)).toBe(false);
+  });
+
+  it('returns false for http(s) / data URLs (not an attachment failure)', () => {
+    expect(hasUnresolvedMediaMarker('MEDIA:https://example.com/a.png', workspace)).toBe(false);
+    expect(hasUnresolvedMediaMarker('MEDIA:data:image/png;base64,AAAA', workspace)).toBe(false);
+  });
+
+  it('returns false for plain text with no markers', () => {
+    expect(hasUnresolvedMediaMarker('画像は作れなかったよ', workspace)).toBe(false);
+  });
+});
+
+describe('getMissingMediaNotice', () => {
+  afterEach(() => {
+    delete process.env.ATTACHMENT_MISSING_NOTICE;
+  });
+
+  it('returns the default notice', () => {
+    delete process.env.ATTACHMENT_MISSING_NOTICE;
+    expect(getMissingMediaNotice()).toContain('添付できませんでした');
+  });
+
+  it('can be overridden via ATTACHMENT_MISSING_NOTICE', () => {
+    process.env.ATTACHMENT_MISSING_NOTICE = 'カスタム注記';
+    expect(getMissingMediaNotice()).toBe('カスタム注記');
+  });
+});
+
+describe('buildAttachmentResult', () => {
+  let workspace: string;
+  let outputsDir: string;
+  let imageRel: string;
+  let imageAbs: string;
+
+  beforeEach(() => {
+    workspace = mkdtempSync(join(tmpdir(), 'xangi-ws-'));
+    outputsDir = join(workspace, 'outputs');
+    mkdirSync(outputsDir, { recursive: true });
+    imageAbs = join(outputsDir, 'real.png');
+    imageRel = 'outputs/real.png';
+    writeFileSync(imageAbs, 'fakepng');
+  });
+
+  afterEach(() => {
+    rmSync(workspace, { recursive: true, force: true });
+    delete process.env.ATTACHMENT_MISSING_NOTICE;
+  });
+
+  it('attaches a real file and strips the marker from display text', () => {
+    const { filePaths, displayText } = buildAttachmentResult(
+      `描いたよ\nMEDIA:${imageRel}`,
+      undefined,
+      workspace
+    );
+    expect(filePaths).toEqual([imageAbs]);
+    expect(displayText).toBe('描いたよ');
+  });
+
+  it('merges and dedupes structured attachments with text-derived paths', () => {
+    const { filePaths } = buildAttachmentResult(`MEDIA:${imageRel}`, [imageAbs], workspace);
+    expect(filePaths).toEqual([imageAbs]);
+  });
+
+  it('appends the failure notice when a phantom MEDIA path resolves to nothing', () => {
+    const { filePaths, displayText } = buildAttachmentResult(
+      `描いたよ！\nMEDIA:outputs/phantom.png`,
+      undefined,
+      workspace
+    );
+    expect(filePaths).toEqual([]);
+    expect(displayText).toContain('描いたよ');
+    expect(displayText).toContain(getMissingMediaNotice());
+  });
+
+  it('returns the notice alone when stripping leaves an empty body', () => {
+    const { filePaths, displayText } = buildAttachmentResult(
+      `MEDIA:outputs/phantom.png`,
+      undefined,
+      workspace
+    );
+    expect(filePaths).toEqual([]);
+    expect(displayText).toBe(getMissingMediaNotice());
+  });
+
+  it('passes plain text through untouched when there are no markers', () => {
+    const { filePaths, displayText } = buildAttachmentResult(
+      '今日はいい天気だね',
+      undefined,
+      workspace
+    );
+    expect(filePaths).toEqual([]);
+    expect(displayText).toBe('今日はいい天気だね');
   });
 });

--- a/tests/local-llm-runner.test.ts
+++ b/tests/local-llm-runner.test.ts
@@ -9,6 +9,7 @@ import {
   loadMessagesFromTranscript,
 } from '../src/local-llm/runner.js';
 import type { TranscriptEntry } from '../src/transcript-logger.js';
+import { FRIENDLY_FALLBACK_MESSAGE } from '../src/local-llm/pseudo-toolcall.js';
 
 describe('isSessionRelatedError', () => {
   it('should return true for "context length exceeded"', () => {
@@ -759,5 +760,120 @@ describe('local-llm runner: compactOldToolResults (Prune)', () => {
     const result = compactOldToolResults(session, 2);
     expect(result.compactedCount).toBe(1);
     expect((session.messages[0] as { content: string }).content).toContain('[tool]');
+  });
+});
+
+describe('non-streaming path drift strip (executeAgentLoop / run)', () => {
+  // scheduler / slash 経路は run() = 非ストリーミングループ (executeAgentLoop) を通る。
+  // このループは drift strip を持たず、`<|channel>thought<channel|>` 等の擬似テキストが
+  // 出力に漏れていた。executeStreamLoop と対称に finalizeNonStreamContent で
+  // strip するようにした回帰テスト。
+  let workdir: string;
+
+  beforeEach(() => {
+    workdir = mkdtempSync(join(tmpdir(), 'xangi-drift-'));
+    mkdirSync(join(workdir, 'logs', 'sessions'), { recursive: true });
+    process.env.LOCAL_LLM_MODE = 'chat'; // enableTools=false → lite 単発 chat 経路
+  });
+
+  afterEach(() => {
+    delete process.env.LOCAL_LLM_MODE;
+    rmSync(workdir, { recursive: true, force: true });
+  });
+
+  function makeRunnerReturning(content: string): LocalLlmRunner {
+    const runner = new LocalLlmRunner({ workdir, model: 'test' });
+    // 実ネットワークを使わず固定応答を返す mock に差し替える
+    (runner as unknown as { llm: { chat: () => Promise<unknown> } }).llm = {
+      chat: async () => ({ content, finishReason: 'stop', toolCalls: [] }),
+    };
+    return runner;
+  }
+
+  it('strips Harmony channel drift leaked on the non-streaming path', async () => {
+    const drift = '<|channel>thought\n<channel|>今日の予定を確認したにゃ🐾\n\n📅 予定はXX';
+    const runner = makeRunnerReturning(drift);
+    const { result } = await runner.run('予定教えて', { sessionId: 's1', channelId: 'c1' });
+    expect(result).not.toContain('<|channel>');
+    expect(result).not.toContain('<channel|>');
+    expect(result).toContain('今日の予定を確認したにゃ');
+  });
+
+  it('replaces drift-only output with friendly fallback (not empty → no misleading ✅)', async () => {
+    const runner = makeRunnerReturning('<|channel>thought\n<channel|>');
+    const { result } = await runner.run('q', { sessionId: 's2', channelId: 'c2' });
+    expect(result).toBe(FRIENDLY_FALLBACK_MESSAGE);
+    expect(result.trim().length).toBeGreaterThan(0);
+  });
+
+  it('leaves clean content untouched', async () => {
+    const runner = makeRunnerReturning('明日は晴れ、最高25℃だよ');
+    const { result } = await runner.run('天気は？', { sessionId: 's3', channelId: 'c3' });
+    expect(result).toBe('明日は晴れ、最高25℃だよ');
+  });
+});
+
+describe('streaming drift-dropped-to-empty recovery (executeStreamLoop / runStream)', () => {
+  // StreamingDriftBuffer が最終応答の strict drift を stream 途中で drop すると fullText が
+  // 空になり、containsPseudoToolCall も false になるため rescue ループも fallback も発火せず、
+  // 呼び出し側の空応答 fallback（誤った成功マーク）に落ちていた。
+  // drift drop を下流に伝え、(1) plain text 再生成を促す (2) 最終的に空なら友好的 fallback。
+  let workdir: string;
+
+  beforeEach(() => {
+    workdir = mkdtempSync(join(tmpdir(), 'xangi-streamdrift-'));
+    mkdirSync(join(workdir, 'logs', 'sessions'), { recursive: true });
+    delete process.env.LOCAL_LLM_MODE; // 既定: enableTools=true → tool ループ → final stream
+  });
+
+  afterEach(() => {
+    rmSync(workdir, { recursive: true, force: true });
+  });
+
+  // chatStream を呼び出し回数ごとに別シーケンスで返す mock を仕込んだ runner を作る
+  function makeStreamRunner(streamsPerCall: string[][]): LocalLlmRunner {
+    const runner = new LocalLlmRunner({ workdir, model: 'test' });
+    let streamCall = 0;
+    (
+      runner as unknown as {
+        llm: {
+          chat: () => Promise<unknown>;
+          chatStream: (m: unknown, o?: unknown) => AsyncGenerator<string>;
+        };
+      }
+    ).llm = {
+      // tool ループは即 break させる（toolCalls 無し）
+      chat: async () => ({ content: '', toolCalls: [], finishReason: 'stop' }),
+      chatStream: async function* () {
+        const chunks = streamsPerCall[Math.min(streamCall, streamsPerCall.length - 1)];
+        streamCall++;
+        for (const c of chunks) yield c;
+      },
+    };
+    return runner;
+  }
+
+  it('falls back to a friendly message (not empty → no ✅) when every stream is drift-only', async () => {
+    // 毎回 strict drift だけを吐く → hold buffer が drop → 空 → retry 上限 → 友好的 fallback
+    const runner = makeStreamRunner([['<|channel>thought\n<channel|>']]);
+    const { result } = await runner.runStream('明日の天気合ってる？', {}, {
+      sessionId: 'st1',
+      channelId: 'ch1',
+    });
+    expect(result).toBe(FRIENDLY_FALLBACK_MESSAGE);
+    expect(result).not.toBe('');
+  });
+
+  it('recovers the real answer when a retry produces clean plain text', async () => {
+    // 1 回目: drift-only（drop → 空）→ 再生成プロンプト → 2 回目: クリーンな本文
+    const runner = makeStreamRunner([
+      ['<|channel>thought\n<channel|>'],
+      ['明日は晴れ時々曇り、最高20℃だよ🐾'],
+    ]);
+    const { result } = await runner.runStream('明日の天気合ってる？', {}, {
+      sessionId: 'st2',
+      channelId: 'ch2',
+    });
+    expect(result).toBe('明日は晴れ時々曇り、最高20℃だよ🐾');
   });
 });

--- a/tests/tool-call-sanitize.test.ts
+++ b/tests/tool-call-sanitize.test.ts
@@ -1,0 +1,123 @@
+import { describe, it, expect } from 'vitest';
+import { stripToolCallArtifacts, finalizeDisplayText } from '../src/tool-call-sanitize.js';
+import { FRIENDLY_FALLBACK_MESSAGE } from '../src/local-llm/pseudo-toolcall.js';
+
+describe('stripToolCallArtifacts', () => {
+  it('ツールコール構文を含まないテキストはそのまま返す', () => {
+    const text = '📚 過去記事から掘り出し物\nずっと欲しかったアプリの話';
+    expect(stripToolCallArtifacts(text)).toBe(text);
+  });
+
+  it('空文字はそのまま返す', () => {
+    expect(stripToolCallArtifacts('')).toBe('');
+  });
+
+  // --- Anthropic / Claude 形式 ---
+
+  it('先頭の call 行 + <invoke>ブロック + 後続テキストから XML だけ消す（実事象の再現）', () => {
+    const leaked =
+      'call\n<invoke name="Bash">\n<parameter name="command">cd /x && uv run python fetch.py | head -c 4000</parameter>\n<parameter name="description">取得</parameter>\n</invoke>記事を選んで X 向けの投稿文を作った。';
+    const out = stripToolCallArtifacts(leaked);
+    expect(out).not.toContain('<invoke');
+    expect(out).not.toContain('<parameter');
+    expect(out).not.toMatch(/(^|\n)call(\n|$)/);
+    expect(out).toContain('記事を選んで X 向けの投稿文を作った。');
+  });
+
+  it('<function_calls> ラッパ形式も除去する', () => {
+    const leaked =
+      '<function_calls>\n<invoke name="Read">\n<parameter name="file_path">/a</parameter>\n</invoke>\n</function_calls>\n本文';
+    const out = stripToolCallArtifacts(leaked);
+    expect(out).not.toContain('<function_calls');
+    expect(out).not.toContain('<invoke');
+    expect(out).toContain('本文');
+  });
+
+  it('閉じタグ欠落でストリームが途中切断した場合は開きタグ以降を落とす', () => {
+    const leaked = '進捗報告です。\ncall\n<invoke name="Bash">\n<parameter name="command">long...';
+    const out = stripToolCallArtifacts(leaked);
+    expect(out).not.toContain('<invoke');
+    expect(out).not.toContain('<parameter');
+    expect(out).toContain('進捗報告です。');
+  });
+
+  it('antml: prefix 付きの invoke も除去する', () => {
+    // リテラルでタグを書くとツール解析を誘発するため連結で組み立てる
+    const open = '<' + 'antml:invoke name="X">';
+    const param = '<' + 'antml:parameter name="p">v</' + 'antml:parameter>';
+    const close = '</' + 'antml:invoke>';
+    const leaked = 'before' + open + param + close + 'after';
+    const out = stripToolCallArtifacts(leaked);
+    expect(out).not.toContain('invoke');
+    expect(out).not.toContain('parameter');
+    expect(out).toBe('beforeafter');
+  });
+
+  it('ツールコール XML だけのブロックは空文字に倒す', () => {
+    const strayOnly =
+      'call\n<invoke name="Bash">\n<parameter name="command">x</parameter>\n</invoke>';
+    expect(stripToolCallArtifacts(strayOnly)).toBe('');
+  });
+
+  // --- Local LLM / Gemma・Harmony 形式（汎用層が pseudo もカバーすることの確認）---
+
+  it('擬似 tool_call（call:fn{args}）も同じ関数で除去する', () => {
+    const leaked = '回答準備中\ncall:tool_search{query:arxiv}\nです。';
+    const out = stripToolCallArtifacts(leaked);
+    expect(out).not.toContain('call:tool_search');
+    expect(out).toContain('回答準備中');
+    expect(out).toContain('です。');
+  });
+
+  it('Harmony channel タグも除去する', () => {
+    expect(stripToolCallArtifacts('前置き<|channel>foo</channel|>後置き', { trim: true })).toBe(
+      '前置き後置き'
+    );
+  });
+
+  // --- 両ファミリ混在（汎用化の意義）---
+
+  it('Anthropic 形式と擬似 tool_call が混在しても両方除去する', () => {
+    const leaked =
+      'まず調べる。\ncall\n<invoke name="Bash">\n<parameter name="command">ls</parameter>\n</invoke>\ncall:tool_search{query:foo}\n結果はこちら。';
+    const out = stripToolCallArtifacts(leaked, { trim: true });
+    expect(out).not.toContain('<invoke');
+    expect(out).not.toContain('call:tool_search');
+    expect(out).toContain('まず調べる。');
+    expect(out).toContain('結果はこちら。');
+  });
+
+  it('trim オプションで前後の空白を落とす', () => {
+    const leaked = '\n\n<invoke name="X"><parameter name="p">v</parameter></invoke>本文\n\n';
+    expect(stripToolCallArtifacts(leaked, { trim: true })).toBe('本文');
+  });
+});
+
+describe('finalizeDisplayText', () => {
+  it('通常テキストはそのまま返す（trim される）', () => {
+    expect(finalizeDisplayText('  画像生成の再現性の話だね  ')).toBe('画像生成の再現性の話だね');
+  });
+
+  it('モデルが本文を出さず空 result の場合は ✅ ではなく fallback を返す（実事象の再現）', () => {
+    // 6/2 21:52 #xangi_work_02: end_turn だが result が空 → Discord 層で `|| '✅'` に落ちた
+    expect(finalizeDisplayText('')).toBe(FRIENDLY_FALLBACK_MESSAGE);
+    expect(finalizeDisplayText('   \n  ')).toBe(FRIENDLY_FALLBACK_MESSAGE);
+  });
+
+  it('null / undefined でも fallback を返す', () => {
+    expect(finalizeDisplayText(null)).toBe(FRIENDLY_FALLBACK_MESSAGE);
+    expect(finalizeDisplayText(undefined)).toBe(FRIENDLY_FALLBACK_MESSAGE);
+  });
+
+  it('tool-call 構文だけで本文が無い場合も fallback を返す（strip → 空 → ✅ を防ぐ）', () => {
+    const onlyXml =
+      'call\n<invoke name="Bash">\n<parameter name="command">ls</parameter>\n</invoke>';
+    expect(finalizeDisplayText(onlyXml)).toBe(FRIENDLY_FALLBACK_MESSAGE);
+  });
+
+  it('構文 + 本文が混在する場合は本文だけ返す', () => {
+    const mixed =
+      'call\n<invoke name="Bash">\n<parameter name="command">ls</parameter>\n</invoke>調べた結果はこう。';
+    expect(finalizeDisplayText(mixed)).toBe('調べた結果はこう。');
+  });
+});


### PR DESCRIPTION
# v0.30.1

バグ修正リリースです。主にローカル LLM 経路での「ツールコール構文の漏れ」「生成失敗の握り潰し」を解消しました。

## 修正

- 生成していないファイルを「添付したつもり」になる問題を解消。モデルが実際にファイルを生成せず出力ファイル名だけを作文して `MEDIA:...` と書いた場合（実在しない捏造パス）を検出し、添付ゼロのまま黙って終わるのではなく「ファイルを生成・添付できませんでした」と正直に通知するようにしました。markdown リンクや http(s)/data URL は通常リンク・外部 URL であって添付失敗ではないため誤検知の対象外です。
- ツールコール構文の表示漏れを汎用サニタイズ層に一本化。`<|channel>thought<channel|>` のような擬似的な内部マーカーが応答本文に混じってユーザに見えてしまうケースを、共通の単一サニタイズ処理で除去するようリファクタリングしました。
- ローカル LLM の非ストリーミング経路（スケジューラ／スラッシュコマンドが通る経路）でのツールコール擬似テキスト漏れを解消。ストリーミング経路にのみ入っていた drift 除去を非ストリーミング経路にも対称的に適用し、cron 投稿などで擬似テキストが Discord に流れるのを止めました。
- 内部マーカーだけで本文が空になった応答が、誤解を招く成功マーク（`✅`）として送信される事象を解消。本文が擬似テキストのみだった場合は、プレーンテキストでの再生成を促す、もしくは正直な fallback メッセージに差し替えるようにしました。

## 環境変数

- `ATTACHMENT_MISSING_NOTICE`（任意）— 添付に失敗したときにユーザへ表示する注記文を上書きできます。未設定時はデフォルトの注記文を使用します。