### PR TITLE
feat: Claude Code の --permission-mode / --add-dir 対応

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -330,6 +330,15 @@ DISCORD_ALLOWED_USER=your_discord_user_id_here
 # 明示的に false を指定する。
 # SKIP_PERMISSIONS=false
 
+# Optional: Claude Code permission mode (SKIP_PERMISSIONS=false のときのみ有効)
+# --dangerously-skip-permissions の代わりに --permission-mode を渡す。
+# 例: acceptEdits（ファイル編集のみ自動許可）, plan, default
+# CLAUDE_PERMISSION_MODE=acceptEdits
+
+# Optional: Claude Code に追加で許可するディレクトリ（カンマ区切り）
+# 各ディレクトリが --add-dir として渡される
+# CLAUDE_ADD_DIRS=/path/to/dir1,/path/to/dir2
+
 # ========================================
 # プロセス管理設定
 # ========================================

--- a/src/base-runner.ts
+++ b/src/base-runner.ts
@@ -16,6 +16,8 @@ export interface BaseRunnerOptions {
   timeoutMs?: number;
   workdir?: string;
   skipPermissions?: boolean;
+  permissionMode?: string;
+  addDirs?: string[];
 }
 
 // プロンプトを再エクスポート（既存のimportを壊さないため）

--- a/src/claude-code.ts
+++ b/src/claude-code.ts
@@ -15,6 +15,8 @@ export interface ClaudeCodeOptions {
   timeoutMs?: number;
   workdir?: string;
   skipPermissions?: boolean;
+  permissionMode?: string;
+  addDirs?: string[];
   platform?: ChatPlatform;
   effort?: string;
 }
@@ -37,6 +39,8 @@ export class ClaudeCodeRunner {
   private timeoutMs: number;
   private workdir?: string;
   private skipPermissions: boolean;
+  private permissionMode?: string;
+  private addDirs?: string[];
   private systemPrompt: string;
   private effort?: string;
 
@@ -45,6 +49,8 @@ export class ClaudeCodeRunner {
     this.timeoutMs = options?.timeoutMs ?? DEFAULT_TIMEOUT_MS; // デフォルト5分
     this.workdir = options?.workdir;
     this.skipPermissions = options?.skipPermissions ?? false;
+    this.permissionMode = options?.permissionMode;
+    this.addDirs = options?.addDirs;
     this.systemPrompt = buildSystemPrompt(options?.platform);
     this.effort = options?.effort;
   }
@@ -56,6 +62,14 @@ export class ClaudeCodeRunner {
     const skip = options?.skipPermissions ?? this.skipPermissions;
     if (skip) {
       args.push('--dangerously-skip-permissions');
+    } else if (this.permissionMode) {
+      args.push('--permission-mode', this.permissionMode);
+    }
+
+    if (this.addDirs && this.addDirs.length > 0) {
+      for (const dir of this.addDirs) {
+        args.push('--add-dir', dir);
+      }
     }
 
     // セッション継続
@@ -183,6 +197,14 @@ export class ClaudeCodeRunner {
     const skip = options?.skipPermissions ?? this.skipPermissions;
     if (skip) {
       args.push('--dangerously-skip-permissions');
+    } else if (this.permissionMode) {
+      args.push('--permission-mode', this.permissionMode);
+    }
+
+    if (this.addDirs && this.addDirs.length > 0) {
+      for (const dir of this.addDirs) {
+        args.push('--add-dir', dir);
+      }
     }
 
     if (options?.sessionId) {

--- a/src/config.ts
+++ b/src/config.ts
@@ -8,6 +8,10 @@ export interface AgentConfig {
   timeoutMs?: number;
   workdir?: string;
   skipPermissions?: boolean;
+  /** Claude Code の --permission-mode（例: acceptEdits, plan, bypassPermissions） */
+  permissionMode?: string;
+  /** Claude Code の --add-dir 追加ディレクトリ一覧 */
+  addDirs?: string[];
   /** 常駐プロセスモード（高速化） */
   persistent?: boolean;
   /** 同時実行プロセス数の上限（RunnerManager用） */
@@ -206,11 +210,21 @@ export function loadConfig(): Config {
   }
   // 複数有効 or 全部 disabled (Web Chat only) → undefined（全コマンド注入 / Web 専用扱い）
 
+  const addDirsRaw = process.env.CLAUDE_ADD_DIRS;
+  const addDirs: string[] | undefined = addDirsRaw
+    ? addDirsRaw
+        .split(',')
+        .map((s) => s.trim())
+        .filter(Boolean)
+    : undefined;
+
   const agentConfig: AgentConfig = {
     model: process.env.AGENT_MODEL || undefined,
     timeoutMs: process.env.TIMEOUT_MS ? parseInt(process.env.TIMEOUT_MS, 10) : DEFAULT_TIMEOUT_MS,
     workdir: process.env.WORKSPACE_PATH || undefined,
     skipPermissions: process.env.SKIP_PERMISSIONS !== 'false', // デフォルトで有効（Discord/Slack/Web 連携の非対話実行で permission プロンプト待ちを避けるため）
+    permissionMode: process.env.CLAUDE_PERMISSION_MODE || undefined,
+    addDirs,
     persistent: process.env.PERSISTENT_MODE !== 'false', // デフォルトで有効
     maxProcesses: process.env.MAX_PROCESSES ? parseInt(process.env.MAX_PROCESSES, 10) : 10,
     idleTimeoutMs: process.env.IDLE_TIMEOUT_MS

--- a/src/persistent-runner.ts
+++ b/src/persistent-runner.ts
@@ -63,6 +63,8 @@ export class PersistentRunner extends EventEmitter implements AgentRunner {
   private currentTimeoutMs = 0;
   private workdir?: string;
   private skipPermissions: boolean;
+  private permissionMode?: string;
+  private addDirs?: string[];
   private systemPrompt: string;
   private resumeSessionId?: string; // プロセス再起動時に --resume で復元するセッションID
   private channelId?: string; // トランスクリプトログ用
@@ -74,6 +76,8 @@ export class PersistentRunner extends EventEmitter implements AgentRunner {
     timeoutMs?: number;
     workdir?: string;
     skipPermissions?: boolean;
+    permissionMode?: string;
+    addDirs?: string[];
     channelId?: string;
     platform?: ChatPlatform;
     effort?: string;
@@ -84,6 +88,8 @@ export class PersistentRunner extends EventEmitter implements AgentRunner {
     this.maxTimeoutMs = MAX_TIMEOUT_MS;
     this.workdir = options?.workdir;
     this.skipPermissions = options?.skipPermissions ?? false;
+    this.permissionMode = options?.permissionMode;
+    this.addDirs = options?.addDirs;
     this.systemPrompt = buildPersistentSystemPrompt(options?.platform);
     this.channelId = options?.channelId;
     this.effort = options?.effort;
@@ -130,6 +136,14 @@ export class PersistentRunner extends EventEmitter implements AgentRunner {
 
     if (this.skipPermissions) {
       args.push('--dangerously-skip-permissions');
+    } else if (this.permissionMode) {
+      args.push('--permission-mode', this.permissionMode);
+    }
+
+    if (this.addDirs && this.addDirs.length > 0) {
+      for (const dir of this.addDirs) {
+        args.push('--add-dir', dir);
+      }
     }
 
     if (this.model) {

--- a/tests/claude-code.test.ts
+++ b/tests/claude-code.test.ts
@@ -112,6 +112,37 @@ describe('ClaudeCodeRunner args', () => {
     expect(args).not.toContain('--dangerously-skip-permissions');
   });
 
+  it('should include --permission-mode when permissionMode is set and skipPermissions is false', async () => {
+    const runner = new ClaudeCodeRunner({ skipPermissions: false, permissionMode: 'acceptEdits' });
+    const { args } = await getSpawnArgs(runner, 'hello');
+
+    expect(args).toContain('--permission-mode');
+    expect(args[args.indexOf('--permission-mode') + 1]).toBe('acceptEdits');
+  });
+
+  it('should prefer --dangerously-skip-permissions over --permission-mode', async () => {
+    const runner = new ClaudeCodeRunner({ skipPermissions: true, permissionMode: 'acceptEdits' });
+    const { args } = await getSpawnArgs(runner, 'hello');
+
+    expect(args).toContain('--dangerously-skip-permissions');
+    expect(args).not.toContain('--permission-mode');
+  });
+
+  it('should include --add-dir for each addDirs entry', async () => {
+    const runner = new ClaudeCodeRunner({
+      skipPermissions: false,
+      addDirs: ['/tmp/dir-a', '/tmp/dir-b'],
+    });
+    const { args } = await getSpawnArgs(runner, 'hello');
+
+    const first = args.indexOf('--add-dir');
+    expect(first).toBeGreaterThan(-1);
+    expect(args[first + 1]).toBe('/tmp/dir-a');
+    const second = args.indexOf('--add-dir', first + 1);
+    expect(second).toBeGreaterThan(-1);
+    expect(args[second + 1]).toBe('/tmp/dir-b');
+  });
+
   it('should include --resume with sessionId', async () => {
     const runner = new ClaudeCodeRunner({});
     const { args } = await getSpawnArgs(runner, 'hello', { sessionId: 'abc-123' });

--- a/tests/config.test.ts
+++ b/tests/config.test.ts
@@ -274,4 +274,28 @@ describe('config', () => {
 
     expect(config.agent.config.skipPermissions).toBe(false);
   });
+
+  it('should read CLAUDE_PERMISSION_MODE and CLAUDE_ADD_DIRS', async () => {
+    process.env.DISCORD_TOKEN = 'test-token';
+    process.env.CLAUDE_PERMISSION_MODE = 'acceptEdits';
+    process.env.CLAUDE_ADD_DIRS = '/tmp/dir-a, /tmp/dir-b';
+
+    const { loadConfig } = await import('../src/config.js');
+    const config = loadConfig();
+
+    expect(config.agent.config.permissionMode).toBe('acceptEdits');
+    expect(config.agent.config.addDirs).toEqual(['/tmp/dir-a', '/tmp/dir-b']);
+  });
+
+  it('should leave permissionMode and addDirs undefined by default', async () => {
+    process.env.DISCORD_TOKEN = 'test-token';
+    delete process.env.CLAUDE_PERMISSION_MODE;
+    delete process.env.CLAUDE_ADD_DIRS;
+
+    const { loadConfig } = await import('../src/config.js');
+    const config = loadConfig();
+
+    expect(config.agent.config.permissionMode).toBeUndefined();
+    expect(config.agent.config.addDirs).toBeUndefined();
+  });
 });


### PR DESCRIPTION
## 概要

`SKIP_PERMISSIONS=false` 時に Claude Code へ `--permission-mode` と `--add-dir` を渡せるようにします。

## 背景

現状、権限まわりの選択肢が次の2択になっています。

- `SKIP_PERMISSIONS=true`（デフォルト）: `--dangerously-skip-permissions` で全権限スキップ
- `SKIP_PERMISSIONS=false`: 非対話実行のため permission プロンプトに誰も答えられず、タスクが進まない

この中間として、Claude Code 標準の permission mode（例: `acceptEdits` = ファイル編集のみ自動許可）を使えると、「全スキップは怖いけど止まるのは困る」というユースケースに対応できます。あわせて、ワークスペース外のディレクトリを扱いたい場合のための `--add-dir` も指定できるようにしました。

## 変更内容

- `CLAUDE_PERMISSION_MODE`: `SKIP_PERMISSIONS=false` のときのみ `--permission-mode <mode>` を付与（`skipPermissions` が優先）
- `CLAUDE_ADD_DIRS`: カンマ区切りで複数指定、各ディレクトリを `--add-dir` として付与
- `ClaudeCodeRunner`（ワンショット）と `PersistentRunner`（常駐）の両方に対応
- `.env.example` に設定例を追記
- テスト追加（config の env 読み込み / spawn 引数の検証）

## 動作確認

- `npm test` 全件パス、`npx tsc --noEmit` パス
- 自宅の Raspberry Pi 環境で `CLAUDE_PERMISSION_MODE=acceptEdits` + `CLAUDE_ADD_DIRS` を約1ヶ月常用しています

🤖 Generated with [Claude Code](https://claude.com/claude-code)
