### PR TITLE
feat: schedule_add で --channel 省略時に発言チャンネルへ登録

### DIFF
--- a/src/cli/schedule-cmd.ts
+++ b/src/cli/schedule-cmd.ts
@@ -58,9 +58,12 @@ async function scheduleList(): Promise<string> {
   return formatScheduleList(schedules);
 }
 
-async function scheduleAdd(flags: Record<string, string>): Promise<string> {
+async function scheduleAdd(
+  flags: Record<string, string>,
+  context?: { channelId?: string }
+): Promise<string> {
   const input = flags['input'];
-  const channelId = flags['channel'];
+  const channelId = flags['channel'] || context?.channelId;
   const platform = (flags['platform'] || 'discord') as 'discord' | 'slack';
 
   if (!input) throw new Error('--input is required');
@@ -126,12 +129,16 @@ async function scheduleToggle(flags: Record<string, string>): Promise<string> {
 
 // ─── Router ─────────────────────────────────────────────────────────
 
-export async function scheduleCmd(command: string, flags: Record<string, string>): Promise<string> {
+export async function scheduleCmd(
+  command: string,
+  flags: Record<string, string>,
+  context?: { channelId?: string }
+): Promise<string> {
   switch (command) {
     case 'schedule_list':
       return scheduleList();
     case 'schedule_add':
-      return scheduleAdd(flags);
+      return scheduleAdd(flags, context);
     case 'schedule_remove':
       return scheduleRemove(flags);
     case 'schedule_toggle':

--- a/src/tool-server.ts
+++ b/src/tool-server.ts
@@ -50,7 +50,7 @@ async function executeCommand(
   if (command.startsWith('discord_') || command === 'media_send') {
     return discordApi(command, flags, context);
   } else if (command.startsWith('schedule_')) {
-    return scheduleCmd(command, flags);
+    return scheduleCmd(command, flags, context);
   } else if (command.startsWith('system_')) {
     return systemCmd(command, flags);
   } else if (command === 'web_history') {

--- a/tests/schedule-cmd.test.ts
+++ b/tests/schedule-cmd.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
-import { mkdtempSync, rmSync, existsSync, mkdirSync } from 'fs';
+import { mkdtempSync, rmSync, existsSync, mkdirSync, readFileSync } from 'fs';
 import { join } from 'path';
 import { tmpdir } from 'os';
 import { scheduleCmd } from '../src/cli/schedule-cmd.js';
@@ -55,5 +55,57 @@ describe('schedule-cmd WORKSPACE_PATH (PR #189)', () => {
   it('returns empty list initially under fresh WORKSPACE_PATH', async () => {
     const result = await scheduleCmd('schedule_list', {});
     expect(result).toContain('スケジュールはありません');
+  });
+});
+
+describe('schedule-cmd context channelId', () => {
+  let tmpDir: string;
+  let originalEnv: NodeJS.ProcessEnv;
+
+  beforeEach(() => {
+    tmpDir = mkdtempSync(join(tmpdir(), 'schedule-cmd-test-'));
+    originalEnv = { ...process.env };
+    delete process.env.DATA_DIR;
+    process.env.WORKSPACE_PATH = tmpDir;
+  });
+
+  afterEach(() => {
+    process.env = originalEnv;
+    rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  function readSchedules(): { channelId: string }[] {
+    const path = join(tmpDir, '.xangi', 'schedules.json');
+    return JSON.parse(readFileSync(path, 'utf-8'));
+  }
+
+  it('uses context.channelId when --channel is omitted', async () => {
+    await scheduleCmd(
+      'schedule_add',
+      { input: '毎日 9:00 おはよう', platform: 'discord' },
+      { channelId: 'ctx-channel' }
+    );
+
+    const schedules = readSchedules();
+    expect(schedules).toHaveLength(1);
+    expect(schedules[0].channelId).toBe('ctx-channel');
+  });
+
+  it('prefers --channel flag over context.channelId', async () => {
+    await scheduleCmd(
+      'schedule_add',
+      { input: '毎日 9:00 おはよう', channel: 'flag-channel', platform: 'discord' },
+      { channelId: 'ctx-channel' }
+    );
+
+    const schedules = readSchedules();
+    expect(schedules).toHaveLength(1);
+    expect(schedules[0].channelId).toBe('flag-channel');
+  });
+
+  it('still requires channel when neither flag nor context is provided', async () => {
+    await expect(scheduleCmd('schedule_add', { input: '毎日 9:00 おはよう' })).rejects.toThrow(
+      '--channel is required'
+    );
   });
 });


### PR DESCRIPTION
## 概要

`xangi-cmd schedule_add` で `--channel` が省略された場合、tool-server の context（発言元チャンネル）をデフォルトとして使うようにします。

## 背景

チャット上で「このチャンネルに毎朝○○を流して」と頼むと、LLM が `schedule_add` を呼ぶ際に `--channel` を付け忘れて `--channel is required` で失敗することがよくあります。発言元チャンネルは tool-server の `context.channelId` として既に伝わっているので、省略時はそれを使うのが自然な挙動だと考えました。

`discord_send` 等の discord 系コマンドが `context.channelId` をデフォルトにしているのと同じ流儀です。

## 変更内容

- `scheduleCmd` / `scheduleAdd` に `context` 引数を追加し、`flags['channel'] || context?.channelId` でフォールバック
- `--channel` の明示指定が常に優先
- どちらも無い場合は従来どおり `--channel is required` エラー
- テスト追加（context フォールバック / フラグ優先 / 両方なしエラー）

## 動作確認

- `npm test` 全件パス、`npx tsc --noEmit` パス
- 自宅環境で約1ヶ月、Discord から「このチャンネルにリマインド登録して」運用で常用しています

🤖 Generated with [Claude Code](https://claude.com/claude-code)
