### PR TITLE
Dependabot 設定を追加

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,26 @@
+version: 2
+updates:
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "09:00"
+      timezone: "Asia/Tokyo"
+    open-pull-requests-limit: 5
+    groups:
+      npm-minor-and-patch:
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "09:00"
+      timezone: "Asia/Tokyo"
+    open-pull-requests-limit: 5


### PR DESCRIPTION
## 概要

- npm dependencies の weekly update を追加
- GitHub Actions の weekly update を追加
- npm の minor / patch update はグループ化

## 背景

依存パッケージの更新漏れと security advisory の見落としを減らすため、公開リポジトリ側に Dependabot 設定を追加します。

## 確認

- `dependabot.yml` の YAML parse 確認
- `git diff --check`