### PR TITLE
Dependabot PR 数を抑制

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,14 +7,23 @@ updates:
       day: "monday"
       time: "09:00"
       timezone: "Asia/Tokyo"
-    open-pull-requests-limit: 5
+    open-pull-requests-limit: 2
+    ignore:
+      - dependency-name: "*"
+        update-types:
+          - "version-update:semver-major"
     groups:
       npm-minor-and-patch:
+        applies-to: "version-updates"
         patterns:
           - "*"
         update-types:
           - "minor"
           - "patch"
+      npm-security:
+        applies-to: "security-updates"
+        patterns:
+          - "*"
 
   - package-ecosystem: "github-actions"
     directory: "/"
@@ -24,3 +33,7 @@ updates:
       time: "09:00"
       timezone: "Asia/Tokyo"
     open-pull-requests-limit: 5
+    groups:
+      github-actions:
+        patterns:
+          - "*"


### PR DESCRIPTION
## 概要

- npm の version update は semver major を無視
- npm version update の open PR 上限を 2 に縮小
- npm security updates をグループ化
- GitHub Actions update をグループ化

## 背景

Dependabot 有効化直後に major update と GitHub Actions update が個別 PR として多数作成されたため、ノイズを抑える設定にします。

## 確認

- `dependabot.yml` の YAML parse 確認
- `git diff --check`

## 参考

- https://docs.github.com/en/code-security/reference/supply-chain-security/dependabot-options-reference
- https://docs.github.com/github/managing-security-vulnerabilities/configuring-dependabot-security-updates