### PR TITLE
Fix Antigravity UTF-8 output decoding

### DIFF
--- a/src/antigravity-cli.ts
+++ b/src/antigravity-cli.ts
@@ -88,7 +88,7 @@ export class AntigravityRunner extends CliRunnerBase {
       logPrompt(this.workdir, options.appSessionId, fullPrompt);
     }
 
-    const stdout = await this.collectOutput(args, options?.channelId);
+    const stdout = await this.collectOutput(args, options?.channelId, { encoding: 'utf8' });
     const response = this.parseResponse(stdout);
     const result = this.extractText(response) || stdout.trim();
     const sessionId =

--- a/src/cli-runner-core.ts
+++ b/src/cli-runner-core.ts
@@ -48,6 +48,8 @@ export interface ExecuteStreamOptions {
 export interface CollectOutputOptions {
   /** exit code != 0 のとき stdout 全文からエラー詳細を抽出する（CLI の error イベント本文など） */
   exitErrorDetail?: (stdout: string) => string | undefined;
+  /** 指定時のみ、Node.js の連続デコーダで stdout / stderr を文字列化する */
+  encoding?: BufferEncoding;
 }
 
 /**
@@ -176,6 +178,11 @@ export abstract class CliRunnerBase extends EventEmitter implements AgentRunner 
 
       let stdout = '';
       let stderr = '';
+
+      if (opts.encoding) {
+        proc.stdout?.setEncoding(opts.encoding);
+        proc.stderr?.setEncoding(opts.encoding);
+      }
 
       proc.stdout?.on('data', (data) => {
         stdout += data.toString();

--- a/tests/antigravity-cli.test.ts
+++ b/tests/antigravity-cli.test.ts
@@ -6,10 +6,11 @@ import { tmpdir } from 'node:os';
 
 vi.mock('child_process', () => {
   const EventEmitter = require('events');
+  const { PassThrough } = require('stream');
 
   class MockProcess extends EventEmitter {
-    stdout = new EventEmitter();
-    stderr = new EventEmitter();
+    stdout = new PassThrough();
+    stderr = new PassThrough();
     killed = false;
 
     kill() {
@@ -112,6 +113,26 @@ describe('AntigravityRunner', () => {
 
     await expect(promise).resolves.toEqual({
       result: 'final answer',
+      sessionId: '',
+    });
+  });
+
+  it('preserves UTF-8 characters split across stdout chunks', async () => {
+    const { getMockProcess } = await import('child_process');
+    const runner = new AntigravityRunner({});
+    const promise = runner.run('hello');
+
+    await new Promise((resolve) => setTimeout(resolve, 50));
+    const mockProcess = (getMockProcess as () => any)();
+    const output = '水を落として根張りを活性化するのがベストです\n';
+
+    for (const byte of Buffer.from(output)) {
+      mockProcess.stdout.write(Buffer.from([byte]));
+    }
+    mockProcess.emit('close', 0);
+
+    await expect(promise).resolves.toEqual({
+      result: output.trim(),
       sessionId: '',
     });
   });


### PR DESCRIPTION
## Purpose

Antigravity CLI (`agy`) の日本語出力で、UTF-8のマルチバイト文字がchild processのstdoutチャンク境界をまたぐと `�` に文字化けする問題を修正します。

原因は、各Bufferチャンクに対して個別に `toString()` を呼んでいたことです。

## Effect

- `CollectOutputOptions` に任意の `encoding` を追加
- AntigravityRunnerだけが `utf8` を指定
- Node.jsの `Readable.setEncoding()` により、分割されたUTF-8文字を次チャンクまで保持
- Claude Code / Codex / Cursor / Grokなど、オプションを指定しない他バックエンドの挙動は変更なし
- stdoutを1バイトずつ流す回帰テストを追加

## Test

```bash
npx vitest run tests/antigravity-cli.test.ts tests/cli-runner-core.test.ts
npx vitest run tests/claude-code.test.ts tests/codex-cli.test.ts tests/cursor-cli.test.ts tests/grok-cli.test.ts tests/persistent-runner.test.ts tests/stale-session-recovery.test.ts
npm run typecheck
npm run build
npm run lint
```

上記はすべて成功しています。

全テストでは1050件中1034件が成功しました。残り16件は、今回変更していないfile-utils/runtime-contextテストにおけるmacOSの一時パス表記差（`/var/...` と `/private/var/...`）です。

## Test Environment

### Hardware

PC (Mac, Apple Silicon / arm64)

### Software(Library)

- Node.js v22.22.3
- npm 10.9.8

## Memo

UTF-8連続デコードはAntigravityの出力収集時だけ明示的に有効化しています。
