### PR TITLE
Release v0.35.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -22,7 +22,6 @@
         "@eslint/js": "^9.39.2",
         "@types/dotenv": "^6.1.1",
         "@types/node": "^22.10.5",
-        "@types/node-cron": "^3.0.11",
         "@types/proper-lockfile": "^4.1.4",
         "@typescript-eslint/eslint-plugin": "^8.19.0",
         "@typescript-eslint/parser": "^8.19.0",
@@ -1650,13 +1649,6 @@
       "dependencies": {
         "undici-types": "~6.21.0"
       }
-    },
-    "node_modules/@types/node-cron": {
-      "version": "3.0.11",
-      "resolved": "https://registry.npmjs.org/@types/node-cron/-/node-cron-3.0.11.tgz",
-      "integrity": "sha512-0ikrnug3/IyneSHqCBeslAhlK2aBfYek1fGo4bP4QnZPmiqSGRK+Oy7ZMisLWkesffJvQ1cqAcBnJC+8+nxIAg==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/@types/proper-lockfile": {
       "version": "4.1.4",
@@ -4028,12 +4020,12 @@
       }
     },
     "node_modules/node-cron": {
-      "version": "4.2.1",
-      "resolved": "https://registry.npmjs.org/node-cron/-/node-cron-4.2.1.tgz",
-      "integrity": "sha512-lgimEHPE/QDgFlywTd8yTR61ptugX3Qer29efeyWw2rv259HtGBNn1vZVmp8lB9uo9wC0t/AT4iGqXxia+CJFg==",
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/node-cron/-/node-cron-4.5.0.tgz",
+      "integrity": "sha512-4Trh+kjvbXokyJkwQumvD5YAgeJfgHLR/sKyu71uSmxfCR5QMO1hldpvmFZOICN5pLgNY+J5Y8+ar3XKo5/4tQ==",
       "license": "ISC",
       "engines": {
-        "node": ">=6.0.0"
+        "node": ">=20"
       }
     },
     "node_modules/object-inspect": {
@@ -5119,9 +5111,9 @@
       }
     },
     "node_modules/undici": {
-      "version": "6.21.3",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-6.21.3.tgz",
-      "integrity": "sha512-gBLkYIlEnSp8pFbT64yFgGE6UIB9tAkhukC23PmMDCe5Nd+cRqKxSjw5y54MK2AZMgZfJWMaNE4nYUHgi1XEOw==",
+      "version": "6.27.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-6.27.0.tgz",
+      "integrity": "sha512-YmfV3YnEDzXRC5lZ2jWtWWHKGUm1zIt8AhesR1tens+HTNv+YZlN/dp6G727LOvMJ8xjP9Be7Y2Sdr96LDm+pg==",
       "license": "MIT",
       "engines": {
         "node": ">=18.17"

--- a/package.json
+++ b/package.json
@@ -50,7 +50,6 @@
     "@eslint/js": "^9.39.2",
     "@types/dotenv": "^6.1.1",
     "@types/node": "^22.10.5",
-    "@types/node-cron": "^3.0.11",
     "@types/proper-lockfile": "^4.1.4",
     "@typescript-eslint/eslint-plugin": "^8.19.0",
     "@typescript-eslint/parser": "^8.19.0",
@@ -66,5 +65,8 @@
   },
   "engines": {
     "node": ">=22.0.0"
+  },
+  "overrides": {
+    "undici": "6.27.0"
   }
 }

--- a/src/scheduler.ts
+++ b/src/scheduler.ts
@@ -9,7 +9,7 @@ import {
   unlinkSync,
 } from 'fs';
 import { dirname, join } from 'path';
-import cron from 'node-cron';
+import cron, { type ScheduledTask } from 'node-cron';
 import { isTransientNetworkError } from './errors.js';
 /** 一時的なネットワークエラー時のリトライ待機時間 (ms)。テストから上書き可能 */
 export const TRANSIENT_RETRY_DELAY_MS = process.env.VITEST ? 50 : 15_000;
@@ -49,7 +49,7 @@ export interface AgentRunFn {
 // ─── Scheduler ───────────────────────────────────────────────────────
 export class Scheduler {
   private schedules: Schedule[] = [];
-  private cronJobs = new Map<string, cron.ScheduledTask>();
+  private cronJobs = new Map<string, ScheduledTask>();
   private timers = new Map<string, ReturnType<typeof setTimeout>>();
   private filePath: string;
   private senders = new Map<Platform, SendMessageFn>();


### PR DESCRIPTION
## v0.35.0

### 修正

- node-cron 4.5.0 で `ScheduledTask` 型参照が壊れる可能性を修正しました。
  - `node-cron` 本体から `ScheduledTask` 型を import するように変更しました。
  - 不要になった `@types/node-cron` を削除しました。

- `undici` の npm audit 指摘に対応しました。
  - `discord.js` / `@discordjs/rest` 経由で使われる `undici` を `6.27.0` に override しました。
  - `undici` / `discord.js` / `@discordjs/rest` の audit 指摘が消えることを確認済みです。

### 補足

- 公開リポジトリ専用の Dependabot 設定は、リリース同期後も保持されます。


### 関連 Issue

- Closes #55
- Closes #56
