### PR TITLE
tool-server を Discord 以外のプラットフォームでも起動する

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -187,6 +187,12 @@ async function main() {
     setApprovalEnabled(true);
   }
 
+  // ツールサーバー起動（Claude Codeからcurlで叩くAPI）
+  // イベントトリガー（POST /api/trigger）は scheduler の agentRunner 経路を再利用
+  const { startToolServer } = await import('./tool-server.js');
+  const { EventTrigger, loadTriggerConfig } = await import('./event-trigger.js');
+  startToolServer({ eventTrigger: new EventTrigger(loadTriggerConfig(), scheduler) });
+
   // Discord ボット: トークン未設定 (Web オンリーモード等) では Client を生成しない。
   // 生成だけでも discord.js の内部リソースを確保するし、login しない Client が
   // 残っているのは紛らわしいため、有効時のみ生成・配線する (issue #173)
@@ -248,12 +254,6 @@ async function main() {
           }
         );
       });
-
-      // ツールサーバー起動（Claude Codeからcurlで叩くAPI）
-      // イベントトリガー（POST /api/trigger）は scheduler の agentRunner 経路を再利用
-      const { startToolServer } = await import('./tool-server.js');
-      const { EventTrigger, loadTriggerConfig } = await import('./event-trigger.js');
-      startToolServer({ eventTrigger: new EventTrigger(loadTriggerConfig(), scheduler) });
 
       const rest = new REST({ version: '10' }).setToken(config.discord.token);
       try {


### PR DESCRIPTION
## 概要

tool-server（Claude Code が curl で叩く API ／ `xangi-cmd` の接続先）の起動位置を `main()` 直下へ移し、**Discord 以外のプラットフォーム（Slack / LINE / Web）単独運用でも起動する**ようにしました。

## 背景・問題

- 従来 `startToolServer(...)` は **Discord クライアントの `ready` イベントハンドラ内**でのみ呼ばれていました。
- そのため Discord トークン未設定の構成（Slack / LINE / Web 単独運用）では `ready` が発火せず、tool-server が起動しません。
- 結果として `XANGI_TOOL_SERVER` が未設定のままになり、`xangi-cmd` 系のコマンドが全て機能しない状態でした。

## 修正内容

- `startToolServer(...)` の呼び出しを Discord の `ready` ハンドラ内から `main()` 直下へ移動。
- プラットフォーム非依存で必ず起動するようにしました。
- イベントトリガー（`POST /api/trigger`）は従来どおり scheduler の `agentRunner` 経路を再利用しており、挙動は変わりません。
- ロジックの移動のみで、新規依存・API 変更はありません（`src/index.ts` のみ、6 行の移動）。

## 影響範囲

- **Discord 運用**: 起動タイミングが `ready` 後から `main()` 内へ早まりますが、起動自体は従来どおり行われるため挙動への影響はありません。
- **Discord 以外の運用**: これまで起動しなかった tool-server が起動するようになります（バグ修正）。

## 動作確認

- `npx tsc --noEmit` 通過
- pre-commit フック（eslint / prettier / vitest）通過
- Slack 単独構成で tool-server が起動し `xangi-cmd` が疎通することを確認