### PR TITLE
Discord の返信をスレッドに投稿するオプションを追加

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -29,6 +29,9 @@ DISCORD_TOKEN=your_discord_bot_token_here
 # Optional: Allow /respondtobots command to toggle the bot-response feature from Discord (default: true)
 # ALLOW_RESPOND_TO_BOTS_COMMAND=true
 
+# Optional: Post replies into a per-message thread instead of the channel (default: false)
+# DISCORD_REPLY_IN_THREAD=true
+
 # Optional: Streaming output (default: true)
 # DISCORD_STREAMING=true
 

--- a/docs/en/usage.md
+++ b/docs/en/usage.md
@@ -976,6 +976,7 @@ To modify the whitelist, edit `ALLOWED_ENV_KEYS` in `src/safe-env.ts`.
 | `DISCORD_TOKEN` | Discord Bot Token | **Required** |
 | `DISCORD_ALLOWED_USER` | Allowed user ID (comma-separated for multiple, `*` to allow all) | **Required** |
 | `AUTO_REPLY_CHANNELS` | Channel IDs to respond without mention (comma-separated) | - |
+| `DISCORD_REPLY_IN_THREAD` | Post replies into a per-message thread instead of the channel | `false` |
 | `DISCORD_STREAMING` | Streaming output | `true` |
 | `DISCORD_SHOW_THINKING` | Show thinking process | `true` |
 | `DISCORD_SHOW_BUTTONS` | Show Stop/New Session buttons | `true` |

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -992,6 +992,7 @@ AIエージェント（CLI spawn / Local LLM exec）に渡す環境変数は `sr
 | `DISCORD_TOKEN` | Discord Bot Token | **必須** |
 | `DISCORD_ALLOWED_USER` | 許可ユーザーID（カンマ区切りで複数可、`*`で全員許可） | **必須** |
 | `AUTO_REPLY_CHANNELS` | メンションなしで応答するチャンネルID（カンマ区切り） | - |
+| `DISCORD_REPLY_IN_THREAD` | 返信をチャンネルではなく発言ごとに作成したスレッドへ投稿 | `false` |
 | `DISCORD_STREAMING` | ストリーミング出力 | `true` |
 | `DISCORD_SHOW_THINKING` | 思考過程を表示 | `true` |
 | `DISCORD_SHOW_BUTTONS` | Stop/New Sessionボタン表示 | `true` |

--- a/src/config.ts
+++ b/src/config.ts
@@ -35,6 +35,8 @@ export interface Config {
     token: string;
     allowedUsers?: string[];
     autoReplyChannels?: string[];
+    /** 返信をチャンネルではなくスレッドに投稿するか (default: false)。発言ごとにスレッドを作成する */
+    replyInThread?: boolean;
     streaming?: boolean;
     showThinking?: boolean;
     showToolUse?: boolean;
@@ -272,6 +274,7 @@ export function loadConfig(): Config {
         process.env.AUTO_REPLY_CHANNELS?.split(',')
           .map((s) => s.trim())
           .filter(Boolean) || [],
+      replyInThread: process.env.DISCORD_REPLY_IN_THREAD === 'true', // デフォルトOFF
       streaming: process.env.DISCORD_STREAMING !== 'false',
       showThinking: process.env.DISCORD_SHOW_THINKING !== 'false',
       showToolUse: process.env.DISCORD_SHOW_TOOL_USE !== 'false',

--- a/src/discord/message-handler.ts
+++ b/src/discord/message-handler.ts
@@ -146,11 +146,45 @@ export async function processPrompt(
     });
     streamSession = session;
 
+    // スレッド返信モード: 発言ごとにスレッドを作成し、以降の投稿先をそのスレッドにする。
+    // すでにスレッド内の発言 / DM など startThread 不可の場合は通常どおりチャンネルへ返信する。
+    let newThread: { send: (options: unknown) => Promise<Message> } | null = null;
+    if (config.discord.replyInThread) {
+      const ch = message.channel as unknown as { isThread?: () => boolean };
+      const alreadyThread = typeof ch.isThread === 'function' && ch.isThread();
+      const canStartThread =
+        typeof (message as unknown as { startThread?: unknown }).startThread === 'function';
+      if (!alreadyThread && canStartThread) {
+        try {
+          const threadName =
+            (stripPromptMetadata(message.content).trim() || 'xangi').slice(0, 80) || 'xangi';
+          newThread = (await (
+            message as unknown as {
+              startThread: (opts: { name: string }) => Promise<unknown>;
+            }
+          ).startThread({ name: threadName })) as { send: (options: unknown) => Promise<Message> };
+        } catch (err) {
+          console.warn(
+            '[xangi] Failed to start thread, falling back to channel:',
+            (err as Error)?.message
+          );
+        }
+      }
+    }
+    // 以降の追加投稿（続きチャンク・ファイル・完了通知）の送信先。
+    // スレッドを新規作成したらそのスレッド、そうでなければ元のチャンネル。
+    const outputChannel = (newThread ?? (message.channel as unknown)) as {
+      send: (options: unknown) => Promise<Message>;
+    };
+
     // 最初のメッセージを送信
-    replyMessage = await message.reply({
+    const firstPayload = {
       content: session.view().statusLine,
       ...(showButtons && { components: [createProcessingButtons()] }),
-    });
+    };
+    replyMessage = newThread
+      ? await newThread.send(firstPayload)
+      : await message.reply(firstPayload);
 
     // タイムアウト UI の自動更新対象として登録 (runner.timeout-* で edit される)
     // runner が agentRunner (DynamicRunnerManager) 経由のときのみ — needsSkipRunner で
@@ -287,8 +321,8 @@ export async function processPrompt(
       content: firstChunks[0] || '✅',
       ...(showButtons && { components: [createCompletedButtons({ showTools: showToolsButton })] }),
     });
-    if ('send' in message.channel) {
-      const channel = message.channel as unknown as {
+    if ('send' in outputChannel) {
+      const channel = outputChannel as unknown as {
         send: (content: string) => Promise<unknown>;
       };
       // 最初のパートの残りチャンク
@@ -306,10 +340,10 @@ export async function processPrompt(
       }
     }
 
-    if (filePaths.length > 0 && 'send' in message.channel) {
+    if (filePaths.length > 0 && 'send' in outputChannel) {
       try {
         await (
-          message.channel as unknown as {
+          outputChannel as unknown as {
             send: (options: { files: { attachment: string }[] }) => Promise<unknown>;
           }
         ).send({
@@ -331,9 +365,9 @@ export async function processPrompt(
       thresholdMs: config.discord.completionNotifyAfterMs ?? 10_000,
       userId: message.author.id,
     });
-    if (completionNotification && 'send' in message.channel) {
+    if (completionNotification && 'send' in outputChannel) {
       await (
-        message.channel as unknown as {
+        outputChannel as unknown as {
           send: (options: {
             content: string;
             allowedMentions: { parse: []; users?: string[] };
@@ -401,12 +435,12 @@ export async function processPrompt(
           if (followUpResult.result) {
             setSession(channelId, followUpResult.sessionId);
             const followUpText = followUpResult.result.slice(0, DISCORD_SAFE_LENGTH);
-            if ('send' in message.channel) {
-              await (
-                message.channel as unknown as {
-                  send: (content: string) => Promise<unknown>;
-                }
-              ).send(`📋 **エラー前の作業報告:**\n${followUpText}`);
+            // スレッド返信時は replyMessage がスレッド内にあるので、その投稿先へ揃える
+            const followUpChannel = (replyMessage?.channel ?? message.channel) as {
+              send?: (content: string) => Promise<unknown>;
+            };
+            if (typeof followUpChannel.send === 'function') {
+              await followUpChannel.send(`📋 **エラー前の作業報告:**\n${followUpText}`);
             }
           }
         }

--- a/tests/config.test.ts
+++ b/tests/config.test.ts
@@ -67,6 +67,26 @@ describe('config', () => {
     expect(config.discord.completionNotifyAfterMs).toBe(60_000);
   });
 
+  it('should default Discord replyInThread to false', async () => {
+    process.env.DISCORD_TOKEN = 'test-discord-token';
+    delete process.env.DISCORD_REPLY_IN_THREAD;
+
+    const { loadConfig } = await import('../src/config.js');
+    const config = loadConfig();
+
+    expect(config.discord.replyInThread).toBe(false);
+  });
+
+  it('should enable Discord replyInThread when DISCORD_REPLY_IN_THREAD=true', async () => {
+    process.env.DISCORD_TOKEN = 'test-discord-token';
+    process.env.DISCORD_REPLY_IN_THREAD = 'true';
+
+    const { loadConfig } = await import('../src/config.js');
+    const config = loadConfig();
+
+    expect(config.discord.replyInThread).toBe(true);
+  });
+
   it('should default to claude-code backend', async () => {
     process.env.DISCORD_TOKEN = 'test-token';
     delete process.env.AGENT_BACKEND;


### PR DESCRIPTION
## 概要

Discord で、返信をチャンネルに直接ではなく**発言ごとに作成したスレッド**へ投稿するオプションを追加します。Slack 側の `replyInThread` 相当の機能を Discord にも用意するものです。

## 動作

- `DISCORD_REPLY_IN_THREAD=true` のとき、ユーザーの発言を起点にスレッドを作成し、ストリーミング返信・続きチャンク・添付ファイル・完了通知をすべてそのスレッド内へ投稿します。
- すでにスレッド内での発言、または DM など `startThread` 不可の場合は従来どおりチャンネルへ返信します（フォールバック）。
- スレッド作成に失敗した場合も従来どおりチャンネルへフォールバックします。
- デフォルトは `false`（従来動作）。

## 変更点

- `src/config.ts`: `discord.replyInThread`（`DISCORD_REPLY_IN_THREAD`、既定 OFF）を追加
- `src/discord/message-handler.ts`: スレッド作成と投稿先（`outputChannel`）の振り分けを実装。エラー後フォローアップも `replyMessage` の投稿先に揃える
- `tests/config.test.ts`: 既定 OFF / `=true` で ON のテストを追加
- ドキュメント（`docs/usage.md` / `docs/en/usage.md` / `.env.example`）に環境変数を追記

## テスト

- `npx tsc --noEmit` 通過
- `npx vitest run`（config / discord 系）通過