### PR TITLE
vitest のテスト探索を tests/ 配下に限定する

### DIFF
--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,7 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    include: ['tests/**/*.test.ts'],
+  },
+});


### PR DESCRIPTION
## 概要

`vitest.config.ts` を追加し、テスト探索対象を `tests/**/*.test.ts` に限定します。

## 背景 / 動機

vitest はデフォルトでリポジトリ配下の `*.test.ts` を広く探索するため、ローカルの作業ディレクトリ（`workspace/`  など）に置いた別プロジェクトのテストファイルまで巻き込んで実行してしまうことがありました。本来のテスト（`tests/` 配下）のみを対象にすることで、探索を安定・高速化します。

## 変更内容

- `vitest.config.ts` を新規追加
  ```ts
  import { defineConfig } from 'vitest/config';

  export default defineConfig({
    test: {
      include: ['tests/**/*.test.ts'],
    },
  });
  ```

## 確認

- `npx vitest run` で `tests/**` のみが探索対象になることを確認（78テストファイルを検出）。