### PR TITLE
Web UI: 表の罫線・コードブロックのコピーボタン・リンクの新タブ表示を追加

### DIFF
--- a/web/index.html
+++ b/web/index.html
@@ -1469,6 +1469,19 @@
         });
       }
 
+      // 描画済みコンテナ内の外部リンク (http/https) を新しいタブで開く。
+      // marked.js は既定でリンクに target を付けないため、innerHTML 代入後に
+      // 付与する。内部リンク (/inter-chat 等) は個別対応済みなので対象外。
+      function addLinkTargets(container) {
+        container.querySelectorAll('a').forEach(function (a) {
+          var href = a.getAttribute('href') || '';
+          if (/^https?:\/\//i.test(href)) {
+            a.setAttribute('target', '_blank');
+            a.setAttribute('rel', 'noopener noreferrer');
+          }
+        });
+      }
+
       function formatTime(isoStr) {
         if (!isoStr) return '';
         const d = new Date(isoStr);
@@ -1707,6 +1720,7 @@
             div.innerHTML = renderMarkdown(cleaned);
             div.style.whiteSpace = 'normal';
             addCodeCopyButtons(div);
+            addLinkTargets(div);
           } else {
             div.textContent = cleaned;
           }
@@ -2156,6 +2170,7 @@
                       assistantDiv.style.whiteSpace = 'normal';
                       assistantDiv.innerHTML = renderMarkdown(d.response || '');
                       addCodeCopyButtons(assistantDiv);
+                      addLinkTargets(assistantDiv);
                       var t = document.createElement('div');
                       t.className = 'msg-time';
                       t.textContent = formatTime(new Date().toISOString());

--- a/web/index.html
+++ b/web/index.html
@@ -491,6 +491,22 @@
         color: var(--ink-subtle);
         margin: 6px 0;
       }
+      .msg.assistant table {
+        border-collapse: collapse;
+        margin: 8px 0;
+        max-width: 100%;
+        display: block;
+        overflow-x: auto;
+      }
+      .msg.assistant th,
+      .msg.assistant td {
+        border: 1px solid var(--hairline-strong);
+        padding: 4px 10px;
+      }
+      .msg.assistant th {
+        background: var(--surface-2);
+        font-weight: 600;
+      }
       .msg-time {
         font-size: 11px;
         color: var(--ink-tertiary);

--- a/web/index.html
+++ b/web/index.html
@@ -526,6 +526,9 @@
         cursor: pointer;
         opacity: 0;
         transition: opacity 0.15s;
+        /* 手動でメッセージ本文をドラッグ選択したときに 'Copy' が
+           選択範囲に含まれないようにする（opacity:0 でも選択対象になるため）。 */
+        user-select: none;
       }
       .msg.assistant pre:hover .code-copy-btn {
         opacity: 1;
@@ -1793,7 +1796,15 @@
           copyBtn.title = 'コピー';
           copyBtn.addEventListener('click', function (ev) {
             ev.stopPropagation();
+            // 各コードブロック内のコピー ボタン (.code-copy-btn) は contentDiv の
+            // 子要素なので、そのまま innerText を読むとボタン文字列
+            // ('Copy'/'Copied'/'Failed') が混入する（opacity:0 でも innerText には
+            // 含まれる）。読み取りの間だけ display:none にして除外する。
+            // clone せず display:none にすることで innerText の改行整形を維持する。
+            var codeBtns = contentDiv.querySelectorAll('.code-copy-btn');
+            codeBtns.forEach(function (n) { n.style.display = 'none'; });
             var txt = contentDiv.innerText || contentDiv.textContent || '';
+            codeBtns.forEach(function (n) { n.style.display = ''; });
             copyText(txt).then(function () {
               copyBtn.textContent = 'Copied';
               setTimeout(function () {

--- a/web/index.html
+++ b/web/index.html
@@ -507,6 +507,33 @@
         background: var(--surface-2);
         font-weight: 600;
       }
+      /* コードブロック右上のコピーボタン */
+      .msg.assistant pre {
+        position: relative;
+      }
+      .code-copy-btn {
+        position: absolute;
+        top: 6px;
+        right: 6px;
+        background: var(--surface-1);
+        border: 1px solid var(--hairline);
+        border-radius: var(--radius-xs);
+        padding: 2px 8px;
+        font-size: 11px !important;
+        line-height: 1.6;
+        color: var(--ink-subtle);
+        font-family: inherit;
+        cursor: pointer;
+        opacity: 0;
+        transition: opacity 0.15s;
+      }
+      .msg.assistant pre:hover .code-copy-btn {
+        opacity: 1;
+      }
+      .code-copy-btn:hover {
+        background: var(--surface-2);
+        color: var(--ink);
+      }
       .msg-time {
         font-size: 11px;
         color: var(--ink-tertiary);
@@ -1386,6 +1413,62 @@
           .replace(/\n/g, '<br>');
       }
 
+      // テキストをクリップボードにコピーする。navigator.clipboard は
+      // セキュアコンテキスト (HTTPS / localhost) でしか使えないため、
+      // http://<hostname>:port 等の insecure な経路では execCommand に
+      // フォールバックする。成否を Promise で返す。
+      function copyText(text) {
+        if (navigator.clipboard && navigator.clipboard.writeText) {
+          return navigator.clipboard.writeText(text);
+        }
+        return new Promise(function (resolve, reject) {
+          try {
+            var ta = document.createElement('textarea');
+            ta.value = text;
+            ta.setAttribute('readonly', '');
+            ta.style.position = 'fixed';
+            ta.style.top = '-9999px';
+            document.body.appendChild(ta);
+            ta.select();
+            var ok = document.execCommand('copy');
+            document.body.removeChild(ta);
+            ok ? resolve() : reject(new Error('execCommand copy failed'));
+          } catch (e) {
+            reject(e);
+          }
+        });
+      }
+
+      // renderMarkdown() が生成した <pre><code> ブロックそれぞれに
+      // コピー ボタンを差し込む。innerHTML 代入後に呼ぶ想定。
+      function addCodeCopyButtons(container) {
+        var blocks = container.querySelectorAll('pre');
+        blocks.forEach(function (pre) {
+          if (pre.querySelector('.code-copy-btn')) return;
+          var btn = document.createElement('button');
+          btn.className = 'code-copy-btn';
+          btn.textContent = 'Copy';
+          btn.title = 'コピー';
+          btn.addEventListener('click', function (ev) {
+            ev.stopPropagation();
+            var codeEl = pre.querySelector('code') || pre;
+            var txt = codeEl.innerText || codeEl.textContent || '';
+            copyText(txt).then(function () {
+              btn.textContent = 'Copied';
+              setTimeout(function () {
+                btn.textContent = 'Copy';
+              }, 1200);
+            }).catch(function () {
+              btn.textContent = 'Failed';
+              setTimeout(function () {
+                btn.textContent = 'Copy';
+              }, 1200);
+            });
+          });
+          pre.appendChild(btn);
+        });
+      }
+
       function formatTime(isoStr) {
         if (!isoStr) return '';
         const d = new Date(isoStr);
@@ -1623,6 +1706,7 @@
           if (role === 'assistant') {
             div.innerHTML = renderMarkdown(cleaned);
             div.style.whiteSpace = 'normal';
+            addCodeCopyButtons(div);
           } else {
             div.textContent = cleaned;
           }
@@ -1696,9 +1780,17 @@
           copyBtn.addEventListener('click', function (ev) {
             ev.stopPropagation();
             var txt = contentDiv.innerText || contentDiv.textContent || '';
-            try {
-              navigator.clipboard.writeText(txt);
-            } catch (_) {}
+            copyText(txt).then(function () {
+              copyBtn.textContent = 'Copied';
+              setTimeout(function () {
+                copyBtn.textContent = 'Copy';
+              }, 1200);
+            }).catch(function () {
+              copyBtn.textContent = 'Failed';
+              setTimeout(function () {
+                copyBtn.textContent = 'Copy';
+              }, 1200);
+            });
           });
           actions.appendChild(copyBtn);
 
@@ -2063,6 +2155,7 @@
                       if (toolsWrapper.parentElement) toolsWrapper.remove();
                       assistantDiv.style.whiteSpace = 'normal';
                       assistantDiv.innerHTML = renderMarkdown(d.response || '');
+                      addCodeCopyButtons(assistantDiv);
                       var t = document.createElement('div');
                       t.className = 'msg-time';
                       t.textContent = formatTime(new Date().toISOString());


### PR DESCRIPTION
## 概要

Web UI の assistant メッセージ表示について、marked.js が生成する Markdown 出力の見やすさ・使い勝手を改善する3点をまとめました。いずれも `web/index.html` 内のスタイル/スクリプトのみの変更で、既存機能には影響しません。

## 変更内容

### 1. 表に罫線を追加
marked.js が生成する `table`/`th`/`td` に `border-collapse` とハイライン色の border を付与し、テーブルとして視認できるようにしました。これまでは罫線が無く、表がプレーンテキストと区別しづらい状態でした。

### 2. コードブロックにコピーボタンを追加
`renderMarkdown()` が生成する各 `<pre>` に、ホバー時に表示されるコピーボタンを差し込む `addCodeCopyButtons()` を追加しました。通常メッセージ表示・ストリーミング応答の確定時の両経路で呼び出しています。

コピー処理は共通ヘルパ `copyText()` に集約しました。`navigator.clipboard` はセキュアコンテキスト（HTTPS / localhost）でしか使えず、`http://<hostname>:port` のような insecure な経路ではコピーが無反応になるため、その場合は `document.execCommand('copy')` に自動フォールバックします。あわせて既存のメッセージ単位コピーボタンも同ヘルパに統一し、コピーの成否をボタン表示（Copied / Failed）で分かるようにしました。

### 3. assistant メッセージ内の外部リンクを新しいタブで開く
marked.js は既定でリンクに `target` を付けないため、応答内のリンクをクリックすると同一タブで遷移し、開いていた画面が失われていました。描画済みコンテナ内の外部リンク（http/https）に `target="_blank"` と `rel="noopener noreferrer"` を付与する `addLinkTargets()` を追加し、`addCodeCopyButtons()` と同じ描画呼び出し箇所で呼びます。内部リンク（`/inter-chat` 等）は個別対応済みのため対象外です。

## 動作確認
- 表を含む応答で罫線が表示されること
- コードブロックにホバーでコピーボタンが出て、クリックで内容がコピーされること
- ストリーミング応答確定後もコピーボタンが機能すること
- `http://<hostname>:port`（insecure context）経由でもコピーが動作すること
- 応答内のリンクをクリックすると新しいタブで開き、既存の画面が保持されること

## 影響範囲
`web/index.html` のみ。バックエンド・API・他プラットフォームには影響なし。
