### PR TITLE
Web UI: フォーカス中ペインをセッション履歴とペイン枠で分かりやすく表示

### DIFF
--- a/web/index.html
+++ b/web/index.html
@@ -191,6 +191,14 @@
         color: var(--ink);
         box-shadow: inset 2px 0 0 var(--primary);
       }
+      /* フォーカス中のペインが開いているセッション（＝現在のペイン） */
+      .session-item.current,
+      .session-item.current:hover {
+        background: var(--focus-ring);
+        color: var(--ink);
+        font-weight: 600;
+        box-shadow: inset 3px 0 0 var(--primary-hover);
+      }
       /* メインエリア（ペイン群コンテナ） */
       #main {
         flex: 1;
@@ -2469,6 +2477,7 @@
           this.panes.forEach((p) => p.el.classList.toggle('active', p === pane));
           this.activePane = pane;
           this._renderTabs();
+          if (typeof updateSessionHighlights === 'function') updateSessionHighlights();
         }
 
         layout() {
@@ -2580,9 +2589,22 @@
         } catch (e) {}
       }
 
+      // フォーカス中ペインのセッションだけ「current」を付け替える（全再描画は不要）
+      function updateSessionHighlights() {
+        var openIds = paneManager.openSessionIds();
+        var currentId = paneManager.activePane ? paneManager.activePane.sessionId : null;
+        var items = sessionListEl.querySelectorAll('.session-item');
+        items.forEach(function (item) {
+          var id = item.getAttribute('data-id');
+          item.classList.toggle('active', openIds.has(id));
+          item.classList.toggle('current', !!currentId && id === currentId);
+        });
+      }
+
       function renderSessions(sessions) {
         sessionListEl.innerHTML = '';
         var openIds = paneManager.openSessionIds();
+        var currentId = paneManager.activePane ? paneManager.activePane.sessionId : null;
         var lastDate = '';
         for (var i = 0; i < sessions.length; i++) {
           var s = sessions[i];
@@ -2595,7 +2617,10 @@
             sessionListEl.appendChild(g);
           }
           var item = document.createElement('div');
-          item.className = 'session-item session-row' + (openIds.has(s.id) ? ' active' : '');
+          item.className =
+            'session-item session-row' +
+            (openIds.has(s.id) ? ' active' : '') +
+            (currentId && s.id === currentId ? ' current' : '');
           var icon =
             s.platform === 'web' ? '\u{1F310}' : s.platform === 'slack' ? '\u{1F4AC}' : '\u{1F48E}';
           var active = s.isActive ? '\u{1F7E2} ' : '';

--- a/web/index.html
+++ b/web/index.html
@@ -352,6 +352,12 @@
       .pane.active .pane-header {
         box-shadow: inset 0 2px 0 var(--primary);
       }
+      /* アクティブペインのタイトル枠の背景をアクセント色に */
+      .pane.active .pane-title:not(.empty),
+      .pane.active .pane-title:not(.empty):hover {
+        background: var(--focus-ring);
+        color: var(--ink);
+      }
       .pane-title {
         flex: 1;
         font-size: 13px;

--- a/web/index.html
+++ b/web/index.html
@@ -321,12 +321,20 @@
         position: relative;
         overflow: hidden;
       }
+      /* 非アクティブなペインをほんの少し沈めて、現在ペインをさりげなく示す */
+      .pane:not(.active) {
+        opacity: 0.82;
+        transition: opacity 0.12s ease;
+      }
+      .pane.active {
+        z-index: 2;
+      }
       .pane.active::after {
         content: '';
         position: absolute;
         inset: 0;
         pointer-events: none;
-        box-shadow: inset 0 0 0 1px var(--primary-focus);
+        box-shadow: inset 0 0 0 2px var(--primary);
         z-index: 1;
       }
       .pane-header {
@@ -338,6 +346,11 @@
         gap: 8px;
         min-height: 40px;
         flex-shrink: 0;
+        transition: box-shadow 0.12s ease;
+      }
+      /* アクティブペインのヘッダー上端に細いアクセントバー */
+      .pane.active .pane-header {
+        box-shadow: inset 0 2px 0 var(--primary);
       }
       .pane-title {
         flex: 1;


### PR DESCRIPTION
## 概要
複数ペインを並べて使うとき「いま入力・操作の対象になっているペインがどれか」が分かりにくい問題を解消します。特にセッション履歴では、開いているセッションが全て同じ見た目で、フォーカス中ペインがどのセッションか判別できませんでした。`web/index.html` のスタイルと軽微なスクリプトのみの変更で、既存機能・レイアウトには影響しません。

## 変更内容
### 1. セッション履歴でフォーカス中ペインのセッションを強調
従来は「ペインで開いているセッション」が全て同一デザインで、どれが現在のペインか区別できませんでした。フォーカス中ペインのセッション行だけ背景色を変えて強調し、ペイン切替時もハイライトが追従します（全再描画せずクラス付け替えのみ）。

### 2. フォーカス中ペイン本体をさりげなく強調
アクティブなペインに枠のアクセント線・ヘッダー上端の細いバー・タイトル枠の背景色を付け、非アクティブなペインをわずかに減光しました。主張しすぎない程度に視線が現在のペインへ向くようにしています。配色は既存テーマ変数（`--primary`/`--focus-ring` 等）を使うためライト/ダーク両テーマに自動追従します。

## 動作確認
- 複数ペインを開き、切り替えるとセッション履歴のハイライトが追従すること
- アクティブなペインが枠・ヘッダーバー・タイトル背景で判別できること
- ライト/ダーク両テーマで破綻しないこと

## 影響範囲
`web/index.html` のみ。バックエンド・API・他プラットフォームに影響なし。
