### PR TITLE
Web UI: ペイン構成のリロード永続化と、送信中ペインを保持したままのスレッド切替/新規チャットを修正

### DIFF
--- a/web/index.html
+++ b/web/index.html
@@ -1191,7 +1191,13 @@
         <button id="menu-btn" onclick="toggleSidebar()">&#9776;</button>
         <h1>xangi</h1>
         <span class="spacer"></span>
-        <a class="tool-link" href="/inter-chat" title="inter-instance-chat 履歴ビューア">
+        <a
+          class="tool-link"
+          href="/inter-chat"
+          target="_blank"
+          rel="noopener"
+          title="inter-instance-chat 履歴ビューア (別タブで開く)"
+        >
           🔁 inter-chat
         </a>
         <a class="tool-link" href="/monitor" title="セッション監視">
@@ -2572,6 +2578,11 @@
         var pane = paneManager.activePane;
         if (!pane) {
           pane = paneManager.add({});
+        } else if (pane.sending) {
+          // アクティブペインが送信中なら中断せず新しいペインで開く
+          // (上限到達で add() が null を返した場合は何もせず諦める)
+          pane = paneManager.add({});
+          if (!pane) return;
         }
         await pane.newSession();
       }

--- a/web/index.html
+++ b/web/index.html
@@ -1220,6 +1220,7 @@
       const addPaneBtn = document.getElementById('add-pane-btn');
 
       const MAX_PANES = 8;
+      const PANE_STATE_KEY = 'xangi_pane_state_v1';
       let allSessions = [];
 
       // ─── タイムアウト管理 ───
@@ -2338,6 +2339,7 @@
                 b.remove();
               });
               loadSessions();
+              if (typeof paneManager !== 'undefined') paneManager._renderTabs();
               this.inputEl.focus();
             }
           } catch (e) {}
@@ -2393,7 +2395,24 @@
           }
         }
 
+        // 開いているペインの並び（各ペインの sessionId）と現在フォーカス中のペインを
+        // localStorage に保存し、ブラウザ更新後も同じ状態を復元できるようにする。
+        // _renderTabs はペイン追加・削除・フォーカス変更・タイトル更新の全経路から
+        // 呼ばれるので、ここに載せておけば個別に persist 呼び出しを散らばせずに済む。
+        _persist() {
+          try {
+            var ids = this.panes.map(function (p) {
+              return p.sessionId || null;
+            });
+            var activeIdx = this.panes.indexOf(this.activePane);
+            localStorage.setItem(PANE_STATE_KEY, JSON.stringify({ ids: ids, activeIdx: activeIdx }));
+          } catch (_) {
+            // localStorage 不可 (プライベートブラウジング等) でも致命的ではないので無視
+          }
+        }
+
         _renderTabs() {
+          this._persist();
           paneTabsEl.innerHTML = '';
           if (this.panes.length === 0) return;
           var self = this;
@@ -2525,6 +2544,10 @@
         var pane = paneManager.activePane;
         if (!pane) {
           pane = paneManager.add({ sessionId: id });
+        } else if (pane.sending) {
+          // アクティブペインが送信中なら中断せず新しいペインで開く
+          // (中断すると裏でバックエンドの処理が走ったまま画面から消えてしまうため)
+          paneManager.add({ sessionId: id });
         } else {
           pane.loadSession(id);
         }
@@ -2846,8 +2869,30 @@
           /* 失敗時はフィルタ無し (全許可) のまま */
         }
         loadSessions();
-        // 起動時に空ペイン1個を用意
-        paneManager.add({});
+        // 前回開いていたペイン構成を localStorage から復元する。
+        // 保存が無い（初回訪問 or 全ペインを閉じた状態で更新した）場合のみ、
+        // 従来通り空ペイン1個を用意する。
+        var restored = false;
+        try {
+          var raw = localStorage.getItem(PANE_STATE_KEY);
+          if (raw) {
+            var saved = JSON.parse(raw);
+            if (saved && Array.isArray(saved.ids) && saved.ids.length > 0) {
+              // add() は上限超過時に alert() を出すので、復元時は静かに切り詰める
+              saved.ids.slice(0, MAX_PANES).forEach(function (id) {
+                paneManager.add(id ? { sessionId: id } : {});
+              });
+              var activePane = paneManager.panes[saved.activeIdx];
+              if (activePane) paneManager.focus(activePane);
+              restored = true;
+            }
+          }
+        } catch (_) {
+          // 壊れた保存データは無視してデフォルト動作にフォールバック
+        }
+        if (!restored) {
+          paneManager.add({});
+        }
       })();
       // ドラッグ&ドロップ：アクティブペインに添付
       document.body.addEventListener('dragover', function (e) {


### PR DESCRIPTION
## 概要
Web UI のペイン操作まわりで2つの問題を修正します。`web/index.html` のみの変更です。

1. ブラウザをリロードするとペイン構成（開いているスレッドの並び・フォーカス位置）が失われ、毎回空ペイン1個からやり直しになっていた。
2. 送信中（応答ストリーミング中）のペインで別スレッドに切り替える / +New Chat する / inter-chat リンクを踏むと、そのペインの処理が巻き込まれて消えてしまっていた。

> 補足: 当初の本文では 1・2 を「進行中処理を中断する」と説明していましたが、実装は逆に **進行中処理を中断せず保持する** 方向です。実挙動に合わせて記述を修正しました。

## 変更内容
### 1. ペイン構成の localStorage 永続化・復元
開いているペインの sessionId 配列とフォーカス位置(activeIdx)を localStorage に保存し、起動時に復元します。保存/復元はペインの追加・削除・フォーカス変更・タイトル更新の全経路が通る `_renderTabs()` に集約しています。
- 壊れた保存値（JSON パース失敗・想定外の形）は無視して従来通り空ペイン1個にフォールバック。
- 復元時に上限(8ペイン)を超える保存があっても alert を出さず静かに切り詰め。

### 2. 送信中ペインを巻き込まず新規ペインで開く
送信中ペインでスレッド切替 / +New Chat した場合、そのペインを中断・上書きせず、**新しいペインを開いてそちらで開く**ようにしました（中断するとバックエンド処理が裏で走り続けたまま画面から消えてしまうため）。inter-chat リンクは同一タブのフルページ遷移で全ペインを失っていたため、別タブで開くよう変更しました。

## 動作確認
- リロード後にペイン構成とフォーカス位置が復元されること
- localStorage が壊れている / 8ペイン超の保存でも安全にフォールバックすること
- 送信中ペインでスレッド切替・+New Chat しても、そのペインが中断されず保持され、新しいペインで開くこと
- inter-chat リンク遷移で他ペインが失われないこと

## 影響範囲
`web/index.html` のみ。バックエンド・API・他プラットフォームに影響なし。
