### PR TITLE
Web UI: スマホでは Enter を改行に使えるよう送信をボタン限定に

### DIFF
--- a/web/index.html
+++ b/web/index.html
@@ -1633,7 +1633,10 @@
 
         _handleKey(e) {
           if (e.isComposing || e.keyCode === 229) return;
-          if (e.key === 'Enter' && !e.shiftKey) {
+          // スマホ幅では Enter を改行に使えるよう、送信はボタンのみに限定する。
+          // ソフトキーボードでは Shift+Enter が事実上打てず、改行が入れられないため。
+          var isMobile = window.matchMedia && window.matchMedia('(max-width: 768px)').matches;
+          if (e.key === 'Enter' && !e.shiftKey && !isMobile) {
             e.preventDefault();
             this.send();
           }


### PR DESCRIPTION
## 概要
スマホ幅で入力欄の Enter が送信に割り当たっているため、改行を入れられない問題を解消します。`web/index.html` のみの小さな変更です。

## 変更内容
ソフトキーボードでは Shift+Enter が事実上打てず、Enter=送信だと本文に改行を入れられません。スマホ幅（`max-width: 768px`）では Enter を改行に使えるようにし、送信は送信ボタンのみに限定しました。デスクトップ幅の挙動（Enter=送信 / Shift+Enter=改行）は変更ありません。

## 動作確認
- スマホ幅で Enter を押すと改行が入り、送信されないこと
- スマホ幅で送信ボタンから送信できること
- デスクトップ幅では従来どおり Enter で送信、Shift+Enter で改行できること

## 影響範囲
`web/index.html` のみ。バックエンド・API・他プラットフォームに影響なし。
