### PR TITLE
Web UI: マルチペインで裏のペイン完了時に入力フォーカスを奪わないよう限定

### DIFF
--- a/web/index.html
+++ b/web/index.html
@@ -2383,7 +2383,10 @@
             clearInterval(thinkingTimer);
             this._setProcessing(false);
             this.abortController = null;
-            this.inputEl.focus();
+            // 裏で完了したペインが手前の入力からフォーカスを奪わないよう、アクティブなペインのみ復帰
+            if (typeof paneManager === 'undefined' || paneManager.activePane === this) {
+              this.inputEl.focus();
+            }
           }
         }
 


### PR DESCRIPTION
## 概要
複数ペインを並べて使うとき、あるペインで入力している最中に裏のペインの応答が完了すると、入力欄のフォーカスとスクロール位置が裏のペイン側へ奪われる問題を解消します。`web/index.html` のみの小さな変更です。

## 変更内容
応答完了時の後処理（finally）が、どのペインの完了かに関わらず無条件に入力欄へフォーカスを戻していました。これを「完了したペインが現在アクティブなときだけフォーカスを戻す」よう限定します。裏で走っていたペインの完了が、手前で入力中のペインを妨げなくなります。

## 動作確認
- 2つのペインを開き、一方で入力しながら他方の応答を完了させても、入力中ペインのフォーカス・スクロールが保たれること
- 単一ペイン時は従来どおり、応答完了で入力欄にフォーカスが戻ること

## 影響範囲
`web/index.html` のみ。バックエンド・API・他プラットフォームに影響なし。
