### PR TITLE
Slack: エージェント出力のMarkdownをSlack mrkdwn記法へ変換して送信

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,6 +17,7 @@
         "grammy": "^1.45.1",
         "node-cron": "^4.6.0",
         "proper-lockfile": "^4.1.2",
+        "slackify-markdown": "^5.0.0",
         "yaml": "^2.9.0"
       },
       "bin": {
@@ -1589,6 +1590,15 @@
         "@types/node": "*"
       }
     },
+    "node_modules/@types/debug": {
+      "version": "4.1.13",
+      "resolved": "https://registry.npmjs.org/@types/debug/-/debug-4.1.13.tgz",
+      "integrity": "sha512-KSVgmQmzMwPlmtljOomayoR89W4FynCAi3E8PPs7vmDVPe84hT+vGPKkJfThkmXs0x0jAaa9U8uW8bbfyS2fWw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/ms": "*"
+      }
+    },
     "node_modules/@types/deep-eql": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
@@ -1662,6 +1672,15 @@
         "@types/node": "*"
       }
     },
+    "node_modules/@types/mdast": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/@types/mdast/-/mdast-4.0.4.tgz",
+      "integrity": "sha512-kGaNbPh1k7AFzgpud/gMdvIm5xuECykRR+JnWKQno9TAXVa6WIVCGTPvYGekIDL4uwCZQSYbUxNBSb1aUo79oA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "*"
+      }
+    },
     "node_modules/@types/ms": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/@types/ms/-/ms-2.1.0.tgz",
@@ -1727,6 +1746,12 @@
         "@types/http-errors": "*",
         "@types/node": "*"
       }
+    },
+    "node_modules/@types/unist": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@types/unist/-/unist-3.0.3.tgz",
+      "integrity": "sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==",
+      "license": "MIT"
     },
     "node_modules/@types/ws": {
       "version": "8.18.1",
@@ -2250,6 +2275,16 @@
         "proxy-from-env": "^2.1.0"
       }
     },
+    "node_modules/bail": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/bail/-/bail-2.0.2.tgz",
+      "integrity": "sha512-0xO6mYd7JB2YesxDKplafRpsiOzPt9V02ddPCLbY1xYGPOX24NTyN50qnUxgCPcSoYMhKpAuBTjQoRZCAkUDRw==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/balanced-match": {
       "version": "4.0.4",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
@@ -2351,6 +2386,16 @@
         "node": ">=6"
       }
     },
+    "node_modules/ccount": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/ccount/-/ccount-2.0.1.tgz",
+      "integrity": "sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/chai": {
       "version": "6.2.2",
       "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
@@ -2376,6 +2421,16 @@
       },
       "funding": {
         "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/character-entities": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/character-entities/-/character-entities-2.0.2.tgz",
+      "integrity": "sha512-shx7oQ0Awen/BRIdkjkvz54PnEEI/EjwXDSIZp86/KKdbafHh1Df/RYGBhn4hbe2+uKC9FnT5UCEdyPz3ai9hQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
       }
     },
     "node_modules/cli-cursor": {
@@ -2550,6 +2605,19 @@
         }
       }
     },
+    "node_modules/decode-named-character-reference": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/decode-named-character-reference/-/decode-named-character-reference-1.3.0.tgz",
+      "integrity": "sha512-GtpQYB283KrPp6nRw50q3U9/VfOutZOe103qlN7BPP6Ad27xYnOIWv4lPzo8HCAL+mMZofJ9KEy30fq6MfaK6Q==",
+      "license": "MIT",
+      "dependencies": {
+        "character-entities": "^2.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/deep-is": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
@@ -2575,6 +2643,15 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/dequal": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
+      "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/detect-libc": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
@@ -2583,6 +2660,19 @@
       "license": "Apache-2.0",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/devlop": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/devlop/-/devlop-1.1.0.tgz",
+      "integrity": "sha512-RWmIqhcFf1lRYBvNmr7qTNuyCt/7/ns2jbpp1+PalgE/rDQcBT0fioSMUpJ93irlUhC5hrg4cYqe6U+0ImW0rA==",
+      "license": "MIT",
+      "dependencies": {
+        "dequal": "^2.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
       }
     },
     "node_modules/discord-api-types": {
@@ -3137,6 +3227,12 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/extend": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
+      "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
+      "license": "MIT"
+    },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
@@ -3664,6 +3760,18 @@
       },
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-plain-obj": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-4.1.0.tgz",
+      "integrity": "sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/is-promise": {
@@ -4238,6 +4346,16 @@
         "url": "https://github.com/chalk/slice-ansi?sponsor=1"
       }
     },
+    "node_modules/longest-streak": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/longest-streak/-/longest-streak-3.1.0.tgz",
+      "integrity": "sha512-9Ri+o0JYgehTaVBBDoMqIl8GXtbWg711O3srftcHhZ0dqnETqLaoIK0x17fUw9rFSlK/0NlsKe0Ahhyl5pXE2g==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/magic-bytes.js": {
       "version": "1.13.0",
       "resolved": "https://registry.npmjs.org/magic-bytes.js/-/magic-bytes.js-1.13.0.tgz",
@@ -4254,6 +4372,16 @@
         "@jridgewell/sourcemap-codec": "^1.5.5"
       }
     },
+    "node_modules/markdown-table": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/markdown-table/-/markdown-table-3.0.4.tgz",
+      "integrity": "sha512-wiYz4+JrLyb/DqW2hkFJxP7Vd7JuTDm77fvbM8VfEQdmSMqcImWeeRbHwZjBjIFki/VaMK2BhFi7oUUZeM5bqw==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/math-intrinsics": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
@@ -4261,6 +4389,207 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/mdast-util-find-and-replace": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/mdast-util-find-and-replace/-/mdast-util-find-and-replace-3.0.2.tgz",
+      "integrity": "sha512-Tmd1Vg/m3Xz43afeNxDIhWRtFZgM2VLyaf4vSTYwudTyeuTneoL3qtWMA5jeLyz/O1vDJmmV4QuScFCA2tBPwg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "escape-string-regexp": "^5.0.0",
+        "unist-util-is": "^6.0.0",
+        "unist-util-visit-parents": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-find-and-replace/node_modules/escape-string-regexp": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-5.0.0.tgz",
+      "integrity": "sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/mdast-util-from-markdown": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/mdast-util-from-markdown/-/mdast-util-from-markdown-2.0.3.tgz",
+      "integrity": "sha512-W4mAWTvSlKvf8L6J+VN9yLSqQ9AOAAvHuoDAmPkz4dHf553m5gVj2ejadHJhoJmcmxEnOv6Pa8XJhpxE93kb8Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "@types/unist": "^3.0.0",
+        "decode-named-character-reference": "^1.0.0",
+        "devlop": "^1.0.0",
+        "mdast-util-to-string": "^4.0.0",
+        "micromark": "^4.0.0",
+        "micromark-util-decode-numeric-character-reference": "^2.0.0",
+        "micromark-util-decode-string": "^2.0.0",
+        "micromark-util-normalize-identifier": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0",
+        "unist-util-stringify-position": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-gfm": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-gfm/-/mdast-util-gfm-3.1.0.tgz",
+      "integrity": "sha512-0ulfdQOM3ysHhCJ1p06l0b0VKlhU0wuQs3thxZQagjcjPrlFRqY215uZGHHJan9GEAXd9MbfPjFJz+qMkVR6zQ==",
+      "license": "MIT",
+      "dependencies": {
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-gfm-autolink-literal": "^2.0.0",
+        "mdast-util-gfm-footnote": "^2.0.0",
+        "mdast-util-gfm-strikethrough": "^2.0.0",
+        "mdast-util-gfm-table": "^2.0.0",
+        "mdast-util-gfm-task-list-item": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-gfm-autolink-literal": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/mdast-util-gfm-autolink-literal/-/mdast-util-gfm-autolink-literal-2.0.1.tgz",
+      "integrity": "sha512-5HVP2MKaP6L+G6YaxPNjuL0BPrq9orG3TsrZ9YXbA3vDw/ACI4MEsnoDpn6ZNm7GnZgtAcONJyPhOP8tNJQavQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "ccount": "^2.0.0",
+        "devlop": "^1.0.0",
+        "mdast-util-find-and-replace": "^3.0.0",
+        "micromark-util-character": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-gfm-footnote": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-gfm-footnote/-/mdast-util-gfm-footnote-2.1.0.tgz",
+      "integrity": "sha512-sqpDWlsHn7Ac9GNZQMeUzPQSMzR6Wv0WKRNvQRg0KqHh02fpTz69Qc1QSseNX29bhz1ROIyNyxExfawVKTm1GQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "devlop": "^1.1.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0",
+        "micromark-util-normalize-identifier": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-gfm-strikethrough": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-gfm-strikethrough/-/mdast-util-gfm-strikethrough-2.0.0.tgz",
+      "integrity": "sha512-mKKb915TF+OC5ptj5bJ7WFRPdYtuHv0yTRxK2tJvi+BDqbkiG7h7u/9SI89nRAYcmap2xHQL9D+QG/6wSrTtXg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-gfm-table": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-gfm-table/-/mdast-util-gfm-table-2.0.0.tgz",
+      "integrity": "sha512-78UEvebzz/rJIxLvE7ZtDd/vIQ0RHv+3Mh5DR96p7cS7HsBhYIICDBCu8csTNWNO6tBWfqXPWekRuj2FNOGOZg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "devlop": "^1.0.0",
+        "markdown-table": "^3.0.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-gfm-task-list-item": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-gfm-task-list-item/-/mdast-util-gfm-task-list-item-2.0.0.tgz",
+      "integrity": "sha512-IrtvNvjxC1o06taBAVJznEnkiHxLFTzgonUdy8hzFVeDun0uTjxxrRGVaNFqkU1wJR3RBPEfsxmU6jDWPofrTQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "devlop": "^1.0.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-phrasing": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-phrasing/-/mdast-util-phrasing-4.1.0.tgz",
+      "integrity": "sha512-TqICwyvJJpBwvGAMZjj4J2n0X8QWp21b9l0o7eXyVJ25YNWYbJDVIyD1bZXE6WtV6RmKJVYmQAKWa0zWOABz2w==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "unist-util-is": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-to-markdown": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/mdast-util-to-markdown/-/mdast-util-to-markdown-2.1.2.tgz",
+      "integrity": "sha512-xj68wMTvGXVOKonmog6LwyJKrYXZPvlwabaryTjLh9LuvovB/KAH+kvi8Gjj+7rJjsFi23nkUxRQv1KqSroMqA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "@types/unist": "^3.0.0",
+        "longest-streak": "^3.0.0",
+        "mdast-util-phrasing": "^4.0.0",
+        "mdast-util-to-string": "^4.0.0",
+        "micromark-util-classify-character": "^2.0.0",
+        "micromark-util-decode-string": "^2.0.0",
+        "unist-util-visit": "^5.0.0",
+        "zwitch": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-to-string": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-to-string/-/mdast-util-to-string-4.0.0.tgz",
+      "integrity": "sha512-0H44vDimn51F0YwvxSJSm0eCDOJTRlmN0R1yBh4HLj9wiV1Dn0QoXGbvFAWj2hSItVTlCmBF1hqKlIyUBVFLPg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
       }
     },
     "node_modules/media-typer": {
@@ -4283,6 +4612,569 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/micromark": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/micromark/-/micromark-4.0.2.tgz",
+      "integrity": "sha512-zpe98Q6kvavpCr1NPVSCMebCKfD7CA2NqZ+rykeNhONIJBpc1tFKt9hucLGwha3jNTNI8lHpctWJWoimVF4PfA==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@types/debug": "^4.0.0",
+        "debug": "^4.0.0",
+        "decode-named-character-reference": "^1.0.0",
+        "devlop": "^1.0.0",
+        "micromark-core-commonmark": "^2.0.0",
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-chunked": "^2.0.0",
+        "micromark-util-combine-extensions": "^2.0.0",
+        "micromark-util-decode-numeric-character-reference": "^2.0.0",
+        "micromark-util-encode": "^2.0.0",
+        "micromark-util-normalize-identifier": "^2.0.0",
+        "micromark-util-resolve-all": "^2.0.0",
+        "micromark-util-sanitize-uri": "^2.0.0",
+        "micromark-util-subtokenize": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-core-commonmark": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/micromark-core-commonmark/-/micromark-core-commonmark-2.0.3.tgz",
+      "integrity": "sha512-RDBrHEMSxVFLg6xvnXmb1Ayr2WzLAWjeSATAoxwKYJV94TeNavgoIdA0a9ytzDSVzBy2YKFK+emCPOEibLeCrg==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "decode-named-character-reference": "^1.0.0",
+        "devlop": "^1.0.0",
+        "micromark-factory-destination": "^2.0.0",
+        "micromark-factory-label": "^2.0.0",
+        "micromark-factory-space": "^2.0.0",
+        "micromark-factory-title": "^2.0.0",
+        "micromark-factory-whitespace": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-chunked": "^2.0.0",
+        "micromark-util-classify-character": "^2.0.0",
+        "micromark-util-html-tag-name": "^2.0.0",
+        "micromark-util-normalize-identifier": "^2.0.0",
+        "micromark-util-resolve-all": "^2.0.0",
+        "micromark-util-subtokenize": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-extension-gfm": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm/-/micromark-extension-gfm-3.0.0.tgz",
+      "integrity": "sha512-vsKArQsicm7t0z2GugkCKtZehqUm31oeGBV/KVSorWSy8ZlNAv7ytjFhvaryUiCUJYqs+NoE6AFhpQvBTM6Q4w==",
+      "license": "MIT",
+      "dependencies": {
+        "micromark-extension-gfm-autolink-literal": "^2.0.0",
+        "micromark-extension-gfm-footnote": "^2.0.0",
+        "micromark-extension-gfm-strikethrough": "^2.0.0",
+        "micromark-extension-gfm-table": "^2.0.0",
+        "micromark-extension-gfm-tagfilter": "^2.0.0",
+        "micromark-extension-gfm-task-list-item": "^2.0.0",
+        "micromark-util-combine-extensions": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-gfm-autolink-literal": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-autolink-literal/-/micromark-extension-gfm-autolink-literal-2.1.0.tgz",
+      "integrity": "sha512-oOg7knzhicgQ3t4QCjCWgTmfNhvQbDDnJeVu9v81r7NltNCVmhPy1fJRX27pISafdjL+SVc4d3l48Gb6pbRypw==",
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-sanitize-uri": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-gfm-footnote": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-footnote/-/micromark-extension-gfm-footnote-2.1.0.tgz",
+      "integrity": "sha512-/yPhxI1ntnDNsiHtzLKYnE3vf9JZ6cAisqVDauhp4CEHxlb4uoOTxOCJ+9s51bIB8U1N1FJ1RXOKTIlD5B/gqw==",
+      "license": "MIT",
+      "dependencies": {
+        "devlop": "^1.0.0",
+        "micromark-core-commonmark": "^2.0.0",
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-normalize-identifier": "^2.0.0",
+        "micromark-util-sanitize-uri": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-gfm-strikethrough": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-strikethrough/-/micromark-extension-gfm-strikethrough-2.1.0.tgz",
+      "integrity": "sha512-ADVjpOOkjz1hhkZLlBiYA9cR2Anf8F4HqZUO6e5eDcPQd0Txw5fxLzzxnEkSkfnD0wziSGiv7sYhk/ktvbf1uw==",
+      "license": "MIT",
+      "dependencies": {
+        "devlop": "^1.0.0",
+        "micromark-util-chunked": "^2.0.0",
+        "micromark-util-classify-character": "^2.0.0",
+        "micromark-util-resolve-all": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-gfm-table": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-table/-/micromark-extension-gfm-table-2.1.1.tgz",
+      "integrity": "sha512-t2OU/dXXioARrC6yWfJ4hqB7rct14e8f7m0cbI5hUmDyyIlwv5vEtooptH8INkbLzOatzKuVbQmAYcbWoyz6Dg==",
+      "license": "MIT",
+      "dependencies": {
+        "devlop": "^1.0.0",
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-gfm-tagfilter": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-tagfilter/-/micromark-extension-gfm-tagfilter-2.0.0.tgz",
+      "integrity": "sha512-xHlTOmuCSotIA8TW1mDIM6X2O1SiX5P9IuDtqGonFhEK0qgRI4yeC6vMxEV2dgyr2TiD+2PQ10o+cOhdVAcwfg==",
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-gfm-task-list-item": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-task-list-item/-/micromark-extension-gfm-task-list-item-2.1.0.tgz",
+      "integrity": "sha512-qIBZhqxqI6fjLDYFTBIa4eivDMnP+OZqsNwmQ3xNLE4Cxwc+zfQEfbs6tzAo2Hjq+bh6q5F+Z8/cksrLFYWQQw==",
+      "license": "MIT",
+      "dependencies": {
+        "devlop": "^1.0.0",
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-factory-destination": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-factory-destination/-/micromark-factory-destination-2.0.1.tgz",
+      "integrity": "sha512-Xe6rDdJlkmbFRExpTOmRj9N3MaWmbAgdpSrBQvCFqhezUn4AHqJHbaEnfbVYYiexVSs//tqOdY/DxhjdCiJnIA==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-factory-label": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-factory-label/-/micromark-factory-label-2.0.1.tgz",
+      "integrity": "sha512-VFMekyQExqIW7xIChcXn4ok29YE3rnuyveW3wZQWWqF4Nv9Wk5rgJ99KzPvHjkmPXF93FXIbBp6YdW3t71/7Vg==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "devlop": "^1.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-factory-space": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-factory-space/-/micromark-factory-space-2.0.1.tgz",
+      "integrity": "sha512-zRkxjtBxxLd2Sc0d+fbnEunsTj46SWXgXciZmHq0kDYGnck/ZSGj9/wULTV95uoeYiK5hRXP2mJ98Uo4cq/LQg==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-factory-title": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-factory-title/-/micromark-factory-title-2.0.1.tgz",
+      "integrity": "sha512-5bZ+3CjhAd9eChYTHsjy6TGxpOFSKgKKJPJxr293jTbfry2KDoWkhBb6TcPVB4NmzaPhMs1Frm9AZH7OD4Cjzw==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-factory-whitespace": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-factory-whitespace/-/micromark-factory-whitespace-2.0.1.tgz",
+      "integrity": "sha512-Ob0nuZ3PKt/n0hORHyvoD9uZhr+Za8sFoP+OnMcnWK5lngSzALgQYKMr9RJVOWLqQYuyn6ulqGWSXdwf6F80lQ==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-character": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-character/-/micromark-util-character-2.1.1.tgz",
+      "integrity": "sha512-wv8tdUTJ3thSFFFJKtpYKOYiGP2+v96Hvk4Tu8KpCAsTMs6yi+nVmGh1syvSCsaxz45J6Jbw+9DD6g97+NV67Q==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-chunked": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-chunked/-/micromark-util-chunked-2.0.1.tgz",
+      "integrity": "sha512-QUNFEOPELfmvv+4xiNg2sRYeS/P84pTW0TCgP5zc9FpXetHY0ab7SxKyAQCNCc1eK0459uoLI1y5oO5Vc1dbhA==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-symbol": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-classify-character": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-classify-character/-/micromark-util-classify-character-2.0.1.tgz",
+      "integrity": "sha512-K0kHzM6afW/MbeWYWLjoHQv1sgg2Q9EccHEDzSkxiP/EaagNzCm7T/WMKZ3rjMbvIpvBiZgwR3dKMygtA4mG1Q==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-combine-extensions": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-combine-extensions/-/micromark-util-combine-extensions-2.0.1.tgz",
+      "integrity": "sha512-OnAnH8Ujmy59JcyZw8JSbK9cGpdVY44NKgSM7E9Eh7DiLS2E9RNQf0dONaGDzEG9yjEl5hcqeIsj4hfRkLH/Bg==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-chunked": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-decode-numeric-character-reference": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/micromark-util-decode-numeric-character-reference/-/micromark-util-decode-numeric-character-reference-2.0.2.tgz",
+      "integrity": "sha512-ccUbYk6CwVdkmCQMyr64dXz42EfHGkPQlBj5p7YVGzq8I7CtjXZJrubAYezf7Rp+bjPseiROqe7G6foFd+lEuw==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-symbol": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-decode-string": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-decode-string/-/micromark-util-decode-string-2.0.1.tgz",
+      "integrity": "sha512-nDV/77Fj6eH1ynwscYTOsbK7rR//Uj0bZXBwJZRfaLEJ1iGBR6kIfNmlNqaqJf649EP0F3NWNdeJi03elllNUQ==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "decode-named-character-reference": "^1.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-decode-numeric-character-reference": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-encode": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-encode/-/micromark-util-encode-2.0.1.tgz",
+      "integrity": "sha512-c3cVx2y4KqUnwopcO9b/SCdo2O67LwJJ/UyqGfbigahfegL9myoEFoDYZgkT7f36T0bLrM9hZTAaAyH+PCAXjw==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/micromark-util-html-tag-name": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-html-tag-name/-/micromark-util-html-tag-name-2.0.1.tgz",
+      "integrity": "sha512-2cNEiYDhCWKI+Gs9T0Tiysk136SnR13hhO8yW6BGNyhOC4qYFnwF1nKfD3HFAIXA5c45RrIG1ub11GiXeYd1xA==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/micromark-util-normalize-identifier": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-normalize-identifier/-/micromark-util-normalize-identifier-2.0.1.tgz",
+      "integrity": "sha512-sxPqmo70LyARJs0w2UclACPUUEqltCkJ6PhKdMIDuJ3gSf/Q+/GIe3WKl0Ijb/GyH9lOpUkRAO2wp0GVkLvS9Q==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-symbol": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-resolve-all": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-resolve-all/-/micromark-util-resolve-all-2.0.1.tgz",
+      "integrity": "sha512-VdQyxFWFT2/FGJgwQnJYbe1jjQoNTS4RjglmSjTUlpUMa95Htx9NHeYW4rGDJzbjvCsl9eLjMQwGeElsqmzcHg==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-sanitize-uri": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-sanitize-uri/-/micromark-util-sanitize-uri-2.0.1.tgz",
+      "integrity": "sha512-9N9IomZ/YuGGZZmQec1MbgxtlgougxTodVwDzzEouPKo3qFWvymFHWcnDi2vzV1ff6kas9ucW+o3yzJK9YB1AQ==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-encode": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-subtokenize": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-util-subtokenize/-/micromark-util-subtokenize-2.1.0.tgz",
+      "integrity": "sha512-XQLu552iSctvnEcgXw6+Sx75GflAPNED1qx7eBJ+wydBb2KCbRZe+NwvIEEMM83uml1+2WSXpBAcp9IUCgCYWA==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "devlop": "^1.0.0",
+        "micromark-util-chunked": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-symbol": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-symbol/-/micromark-util-symbol-2.0.1.tgz",
+      "integrity": "sha512-vs5t8Apaud9N28kgCrRUdEed4UJ+wWNvicHLPxCa9ENlYuAY31M0ETy5y1vA33YoNPDFTghEbnh6efaE8h4x0Q==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/micromark-util-types": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/micromark-util-types/-/micromark-util-types-2.0.2.tgz",
+      "integrity": "sha512-Yw0ECSpJoViF1qTU4DC6NwtC4aWGt1EkzaQB8KPPyCRR8z9TWeV0HbEFGTO+ZY1wB22zmxnJqhPyTpOVCpeHTA==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT"
     },
     "node_modules/mime-db": {
       "version": "1.54.0",
@@ -4802,6 +5694,55 @@
         "node": ">= 0.10"
       }
     },
+    "node_modules/remark-gfm": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/remark-gfm/-/remark-gfm-4.0.1.tgz",
+      "integrity": "sha512-1quofZ2RQ9EWdeN34S79+KExV1764+wCUGop5CPL1WGdD0ocPpu91lzPGbwWMECpEpd42kJGQwzRfyov9j4yNg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "mdast-util-gfm": "^3.0.0",
+        "micromark-extension-gfm": "^3.0.0",
+        "remark-parse": "^11.0.0",
+        "remark-stringify": "^11.0.0",
+        "unified": "^11.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/remark-parse": {
+      "version": "11.0.0",
+      "resolved": "https://registry.npmjs.org/remark-parse/-/remark-parse-11.0.0.tgz",
+      "integrity": "sha512-FCxlKLNGknS5ba/1lmpYijMUzX2esxW5xQqjWxw2eHFfS2MSdaHVINFmhjo+qN1WhZhNimq0dZATN9pH0IDrpA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "micromark-util-types": "^2.0.0",
+        "unified": "^11.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/remark-stringify": {
+      "version": "11.0.0",
+      "resolved": "https://registry.npmjs.org/remark-stringify/-/remark-stringify-11.0.0.tgz",
+      "integrity": "sha512-1OSmLd3awB/t8qdoEOMazZkNsfVTeY4fTsgzcQFdXNq8ToTN4ZGwrMnlda4K6smTFKD+GRV6O48i6Z4iKgPPpw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "mdast-util-to-markdown": "^2.0.0",
+        "unified": "^11.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
     "node_modules/resolve-from": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
@@ -5105,6 +6046,24 @@
       "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
       "license": "ISC"
     },
+    "node_modules/slackify-markdown": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/slackify-markdown/-/slackify-markdown-5.0.0.tgz",
+      "integrity": "sha512-jTWvwjOYGAqS0NNyhTm+9H8S0/tux2anPEwyeIBCayH14jGHIrN70yj4afUYP2zq54aUwEFkASdXytjO/5GA+A==",
+      "license": "MIT",
+      "dependencies": {
+        "mdast-util-to-markdown": "^2.1.2",
+        "remark-gfm": "^4.0.0",
+        "remark-parse": "^11.0.0",
+        "remark-stringify": "^11.0.0",
+        "unified": "^11.0.5",
+        "unist-util-remove": "^4.0.0",
+        "unist-util-visit": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=22"
+      }
+    },
     "node_modules/slice-ansi": {
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-8.0.0.tgz",
@@ -5305,6 +6264,16 @@
       "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
       "license": "MIT"
     },
+    "node_modules/trough": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/trough/-/trough-2.2.0.tgz",
+      "integrity": "sha512-tmMpK00BjZiUyVyvrBK7knerNgmgvcV/KLVyuma/SC+TQN167GrMRciANTz09+k3zW8L8t60jWO1GpfkZdjTaw==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/ts-api-utils": {
       "version": "2.5.0",
       "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-2.5.0.tgz",
@@ -5442,6 +6411,95 @@
       "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
       "license": "MIT"
     },
+    "node_modules/unified": {
+      "version": "11.0.5",
+      "resolved": "https://registry.npmjs.org/unified/-/unified-11.0.5.tgz",
+      "integrity": "sha512-xKvGhPWw3k84Qjh8bI3ZeJjqnyadK+GEFtazSfZv/rKeTkTjOJho6mFqh2SM96iIcZokxiOpg78GazTSg8+KHA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "bail": "^2.0.0",
+        "devlop": "^1.0.0",
+        "extend": "^3.0.0",
+        "is-plain-obj": "^4.0.0",
+        "trough": "^2.0.0",
+        "vfile": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-is": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/unist-util-is/-/unist-util-is-6.0.1.tgz",
+      "integrity": "sha512-LsiILbtBETkDz8I9p1dQ0uyRUWuaQzd/cuEeS1hoRSyW5E5XGmTzlwY1OrNzzakGowI9Dr/I8HVaw4hTtnxy8g==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-remove": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/unist-util-remove/-/unist-util-remove-4.0.0.tgz",
+      "integrity": "sha512-b4gokeGId57UVRX/eVKej5gXqGlc9+trkORhFJpu9raqZkZhU0zm8Doi05+HaiBsMEIJowL+2WtQ5ItjsngPXg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "unist-util-is": "^6.0.0",
+        "unist-util-visit-parents": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-stringify-position": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/unist-util-stringify-position/-/unist-util-stringify-position-4.0.0.tgz",
+      "integrity": "sha512-0ASV06AAoKCDkS2+xw5RXJywruurpbC4JZSm7nr7MOt1ojAzvyyaO+UxZf18j8FCF6kmzCZKcAgN/yu2gm2XgQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-visit": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/unist-util-visit/-/unist-util-visit-5.1.0.tgz",
+      "integrity": "sha512-m+vIdyeCOpdr/QeQCu2EzxX/ohgS8KbnPDgFni4dQsfSCtpz8UqDyY5GjRru8PDKuYn7Fq19j1CQ+nJSsGKOzg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "unist-util-is": "^6.0.0",
+        "unist-util-visit-parents": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-visit-parents": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/unist-util-visit-parents/-/unist-util-visit-parents-6.0.2.tgz",
+      "integrity": "sha512-goh1s1TBrqSqukSc8wrjwWhL0hiJxgA8m4kFxGlQ+8FYQ3C/m11FcTs4YYem7V664AhHVvgoQLk890Ssdsr2IQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "unist-util-is": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
     "node_modules/universal-github-app-jwt": {
       "version": "2.2.2",
       "resolved": "https://registry.npmjs.org/universal-github-app-jwt/-/universal-github-app-jwt-2.2.2.tgz",
@@ -5480,6 +6538,34 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/vfile": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/vfile/-/vfile-6.0.3.tgz",
+      "integrity": "sha512-KzIbH/9tXat2u30jf+smMwFCsno4wHVdNmzFyL+T/L3UGqqk6JKfVqOFOZEpZSHADH1k40ab6NUIXZq422ov3Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "vfile-message": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/vfile-message": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/vfile-message/-/vfile-message-4.0.3.tgz",
+      "integrity": "sha512-QTHzsGd1EhbZs4AsQ20JX1rC3cOlt/IWJruk893DfLRr57lcnOeMaWG4K0JrRta4mIJZKth2Au3mM3u03/JWKw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "unist-util-stringify-position": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
       }
     },
     "node_modules/vite": {
@@ -5811,6 +6897,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/zwitch": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/zwitch/-/zwitch-2.0.4.tgz",
+      "integrity": "sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
     "grammy": "^1.45.1",
     "node-cron": "^4.6.0",
     "proper-lockfile": "^4.1.2",
+    "slackify-markdown": "^5.0.0",
     "yaml": "^2.9.0"
   },
   "devDependencies": {

--- a/src/slack-mrkdwn.ts
+++ b/src/slack-mrkdwn.ts
@@ -1,0 +1,174 @@
+// Markdown（エージェントの出力）を Slack の mrkdwn 記法へ変換する。
+// Slack のメッセージ text は既定で mrkdwn として描画されるため、記法の差分を吸収すれば
+// 太字・斜体・リンク・箇条書き・見出し・表がそのまま整形表示される。
+//
+// 標準Markdown → Slack mrkdwn の主な差分:
+//   **bold** / __bold__ → *bold*
+//   *italic*            → _italic_
+//   ~~strike~~          → ~strike~
+//   # 見出し            → *見出し*（Slackに見出し記法がないため太字で代替）
+//   [text](url)         → <url|text>
+//   - / * / + 箇条書き  → • 箇条書き
+//   表                  → 等幅整形してコードブロックで囲む（Slackは表未対応）
+//   `code` / ```block```→ そのまま（Slackが対応）
+
+const PLACEHOLDER_OPEN = '\uE000';
+const PLACEHOLDER_CLOSE = '\uE001';
+const BOLD_MARK = '\uE002';
+
+// 保護したいコード片（フェンス/インライン/整形済み表）を退避し、プレースホルダに置換する。
+class CodeVault {
+  private tokens: string[] = [];
+
+  stash(content: string): string {
+    const index = this.tokens.push(content) - 1;
+    return `${PLACEHOLDER_OPEN}${index}${PLACEHOLDER_CLOSE}`;
+  }
+
+  restore(text: string): string {
+    return text.replace(
+      new RegExp(`${PLACEHOLDER_OPEN}(\\d+)${PLACEHOLDER_CLOSE}`, 'g'),
+      (_, i: string) => this.tokens[Number(i)] ?? ''
+    );
+  }
+}
+
+// フェンス付きコードブロックとインラインコードを退避する。
+function protectCode(text: string, vault: CodeVault): string {
+  // ```lang\n ... ``` （Slackはフェンス対応。中身は一切変換しない）
+  let out = text.replace(/```[\s\S]*?```/g, (m) => vault.stash(m));
+  // `inline code`
+  out = out.replace(/`[^`\n]+`/g, (m) => vault.stash(m));
+  return out;
+}
+
+// Markdownの表を等幅整形し、コードブロックとして退避する。
+function protectTables(text: string, vault: CodeVault): string {
+  const lines = text.split('\n');
+  const result: string[] = [];
+  const isSeparator = (line: string): boolean =>
+    /^\s*\|?[\s:|-]*-{3,}[\s:|-]*\|?\s*$/.test(line) && line.includes('-');
+  const looksLikeRow = (line: string): boolean => line.includes('|');
+
+  for (let i = 0; i < lines.length; i++) {
+    if (i + 1 < lines.length && looksLikeRow(lines[i]) && isSeparator(lines[i + 1])) {
+      const block: string[] = [lines[i], lines[i + 1]];
+      let j = i + 2;
+      while (j < lines.length && looksLikeRow(lines[j]) && lines[j].trim() !== '') {
+        block.push(lines[j]);
+        j++;
+      }
+      result.push(vault.stash('```\n' + renderTable(block) + '\n```'));
+      i = j - 1;
+      continue;
+    }
+    result.push(lines[i]);
+  }
+  return result.join('\n');
+}
+
+// 表の行配列を、列幅を揃えた等幅テキストへ整形する（区切り行は罫線に置換）。
+function renderTable(block: string[]): string {
+  const splitRow = (line: string): string[] =>
+    line
+      .replace(/^\s*\|/, '')
+      .replace(/\|\s*$/, '')
+      .split('|')
+      .map((c) => c.trim());
+
+  const header = splitRow(block[0]);
+  const bodyRows = block.slice(2).map(splitRow);
+  const colCount = Math.max(header.length, ...bodyRows.map((r) => r.length));
+  const widths = new Array<number>(colCount).fill(0);
+
+  const allRows = [header, ...bodyRows];
+  for (const row of allRows) {
+    for (let c = 0; c < colCount; c++) {
+      widths[c] = Math.max(widths[c], displayWidth(row[c] ?? ''));
+    }
+  }
+
+  const pad = (cell: string, width: number): string =>
+    cell + ' '.repeat(Math.max(0, width - displayWidth(cell)));
+  const formatRow = (row: string[]): string =>
+    row.map((cell, c) => pad(cell ?? '', widths[c])).join('  ');
+
+  const divider = widths.map((w) => '─'.repeat(w)).join('──');
+  return [formatRow(header), divider, ...bodyRows.map(formatRow)].join('\n');
+}
+
+// 全角文字を2幅として数える簡易表示幅。
+function displayWidth(text: string): number {
+  let width = 0;
+  for (const ch of text) {
+    const cp = ch.codePointAt(0) ?? 0;
+    // Latin-1範囲(<=0xFF)は1幅、半角カナ(0xFF61-0xFF9F)も1幅、それ以外の全角は2幅
+    const halfKana = cp >= 0xff61 && cp <= 0xff9f;
+    width += cp > 0xff && !halfKana ? 2 : 1;
+  }
+  return width;
+}
+
+// 行単位の変換（見出し・水平線・箇条書き）。
+function convertBlocks(text: string): string {
+  return text
+    .split('\n')
+    .map((line) => {
+      // 水平線: ---, ***, ___ のみの行
+      if (/^\s*([-*_])\s*(\1\s*){2,}$/.test(line)) {
+        return '──────────';
+      }
+      // 見出し: # 〜 ###### → 太字
+      const heading = line.match(/^\s{0,3}(#{1,6})\s+(.*?)\s*#*\s*$/);
+      if (heading) {
+        // 太字マーカー経由にして後段の斜体変換に巻き込まれないようにする
+        return `${BOLD_MARK}${heading[2]}${BOLD_MARK}`;
+      }
+      // 箇条書き: -, *, + → •（インデント維持）
+      const bullet = line.match(/^(\s*)[-*+]\s+(.*)$/);
+      if (bullet) {
+        return `${bullet[1]}• ${bullet[2]}`;
+      }
+      return line;
+    })
+    .join('\n');
+}
+
+// インライン装飾の変換（太字・斜体・打ち消し・リンク）。
+function convertInline(text: string): string {
+  let out = text;
+  // 画像 ![alt](url) → <url|alt>
+  out = out.replace(
+    /!\[([^\]]*)\]\(([^)\s]+)(?:\s+"[^"]*")?\)/g,
+    (_, alt, url) => `<${url}|${alt || url}>`
+  );
+  // リンク [text](url) → <url|text>
+  out = out.replace(
+    /\[([^\]]+)\]\(([^)\s]+)(?:\s+"[^"]*")?\)/g,
+    (_, label, url) => `<${url}|${label}>`
+  );
+  // 太字斜体 ***x*** → *_x_*
+  out = out.replace(/\*\*\*([^\n]+?)\*\*\*/g, `${BOLD_MARK}_$1_${BOLD_MARK}`);
+  // 太字 **x** / __x__ → 一時マーク
+  out = out.replace(/\*\*([^\n]+?)\*\*/g, `${BOLD_MARK}$1${BOLD_MARK}`);
+  out = out.replace(/__([^\n_]+?)__/g, `${BOLD_MARK}$1${BOLD_MARK}`);
+  // 打ち消し ~~x~~ → ~x~
+  out = out.replace(/~~([^\n]+?)~~/g, '~$1~');
+  // 斜体 *x* → _x_（前後が空白/記号のときのみ。箇条書きの残骸を巻き込まない）
+  out = out.replace(/(^|[^*\w])\*(?!\s)([^*\n]+?)(?<!\s)\*(?![*\w])/g, '$1_$2_');
+  // 太字マークを復元
+  out = out.split(BOLD_MARK).join('*');
+  return out;
+}
+
+// Markdown文字列を Slack mrkdwn へ変換する。
+export function markdownToSlackMrkdwn(markdown: string): string {
+  if (!markdown) return markdown;
+  const vault = new CodeVault();
+  let text = protectCode(markdown, vault);
+  text = protectTables(text, vault);
+  text = convertBlocks(text);
+  text = convertInline(text);
+  text = vault.restore(text);
+  return text;
+}

--- a/src/slack-mrkdwn.ts
+++ b/src/slack-mrkdwn.ts
@@ -34,6 +34,12 @@ class CodeVault {
   }
 }
 
+// CommonMark で有効な [text](<url>) 形式を、slackify-markdown が扱える
+// [text](url) 形式へ正規化する。コード内は protectCode で先に退避済み。
+function normalizeAngleBracketLinkDestinations(text: string): string {
+  return text.replace(/(!?\[[^\]\n]*\])\(<((?:https?:\/\/|ftp:\/\/|mailto:)[^>\n]+)>\)/g, '$1($2)');
+}
+
 // フェンス付きコードブロックとインラインコードを退避する。
 function protectCode(text: string, vault: CodeVault): string {
   // ```lang\n ... ``` （Slackはフェンス対応。中身は一切変換しない）
@@ -143,6 +149,7 @@ export function markdownToSlackMrkdwn(markdown: string): string {
   if (!markdown) return markdown;
   const vault = new CodeVault();
   let text = protectCode(markdown, vault);
+  text = normalizeAngleBracketLinkDestinations(text);
   text = protectTables(text, vault);
   text = protectSlackMrkdwn(text, vault);
   text = convertBlocks(text, vault);

--- a/src/slack-mrkdwn.ts
+++ b/src/slack-mrkdwn.ts
@@ -1,3 +1,5 @@
+import { slackifyMarkdown } from 'slackify-markdown';
+
 // Markdown（エージェントの出力）を Slack の mrkdwn 記法へ変換する。
 // Slack のメッセージ text は既定で mrkdwn として描画されるため、記法の差分を吸収すれば
 // 太字・斜体・リンク・箇条書き・見出し・表がそのまま整形表示される。
@@ -14,7 +16,6 @@
 
 const PLACEHOLDER_OPEN = '\uE000';
 const PLACEHOLDER_CLOSE = '\uE001';
-const BOLD_MARK = '\uE002';
 
 // 保護したいコード片（フェンス/インライン/整形済み表）を退避し、プレースホルダに置換する。
 class CodeVault {
@@ -40,6 +41,14 @@ function protectCode(text: string, vault: CodeVault): string {
   // `inline code`
   out = out.replace(/`[^`\n]+`/g, (m) => vault.stash(m));
   return out;
+}
+
+// エージェントがすでに出力した Slack 固有リンク・mention・日付記法を退避する。
+// slackify-markdown は Markdown の autolink として再解釈するため、変換前の保護が必要。
+function protectSlackMrkdwn(text: string, vault: CodeVault): string {
+  return text.replace(/<(?:https?:\/\/|ftp:\/\/|mailto:|[@#!])[^>\n]+>/g, (match) =>
+    vault.stash(match)
+  );
 }
 
 // Markdownの表を等幅整形し、コードブロックとして退避する。
@@ -109,8 +118,8 @@ function displayWidth(text: string): number {
   return width;
 }
 
-// 行単位の変換（見出し・水平線・箇条書き）。
-function convertBlocks(text: string): string {
+// slackify-markdown が表現を変える水平線とネスト箇条書きだけ先に整える。
+function convertBlocks(text: string, vault: CodeVault): string {
   return text
     .split('\n')
     .map((line) => {
@@ -118,47 +127,15 @@ function convertBlocks(text: string): string {
       if (/^\s*([-*_])\s*(\1\s*){2,}$/.test(line)) {
         return '──────────';
       }
-      // 見出し: # 〜 ###### → 太字
-      const heading = line.match(/^\s{0,3}(#{1,6})\s+(.*?)\s*#*\s*$/);
-      if (heading) {
-        // 太字マーカー経由にして後段の斜体変換に巻き込まれないようにする
-        return `${BOLD_MARK}${heading[2]}${BOLD_MARK}`;
-      }
       // 箇条書き: -, *, + → •（インデント維持）
       const bullet = line.match(/^(\s*)[-*+]\s+(.*)$/);
       if (bullet) {
-        return `${bullet[1]}• ${bullet[2]}`;
+        const indent = bullet[1] ? vault.stash(bullet[1]) : '';
+        return `${indent}• ${bullet[2]}`;
       }
       return line;
     })
     .join('\n');
-}
-
-// インライン装飾の変換（太字・斜体・打ち消し・リンク）。
-function convertInline(text: string): string {
-  let out = text;
-  // 画像 ![alt](url) → <url|alt>
-  out = out.replace(
-    /!\[([^\]]*)\]\(([^)\s]+)(?:\s+"[^"]*")?\)/g,
-    (_, alt, url) => `<${url}|${alt || url}>`
-  );
-  // リンク [text](url) → <url|text>
-  out = out.replace(
-    /\[([^\]]+)\]\(([^)\s]+)(?:\s+"[^"]*")?\)/g,
-    (_, label, url) => `<${url}|${label}>`
-  );
-  // 太字斜体 ***x*** → *_x_*
-  out = out.replace(/\*\*\*([^\n]+?)\*\*\*/g, `${BOLD_MARK}_$1_${BOLD_MARK}`);
-  // 太字 **x** / __x__ → 一時マーク
-  out = out.replace(/\*\*([^\n]+?)\*\*/g, `${BOLD_MARK}$1${BOLD_MARK}`);
-  out = out.replace(/__([^\n_]+?)__/g, `${BOLD_MARK}$1${BOLD_MARK}`);
-  // 打ち消し ~~x~~ → ~x~
-  out = out.replace(/~~([^\n]+?)~~/g, '~$1~');
-  // 斜体 *x* → _x_（前後が空白/記号のときのみ。箇条書きの残骸を巻き込まない）
-  out = out.replace(/(^|[^*\w])\*(?!\s)([^*\n]+?)(?<!\s)\*(?![*\w])/g, '$1_$2_');
-  // 太字マークを復元
-  out = out.split(BOLD_MARK).join('*');
-  return out;
 }
 
 // Markdown文字列を Slack mrkdwn へ変換する。
@@ -167,8 +144,11 @@ export function markdownToSlackMrkdwn(markdown: string): string {
   const vault = new CodeVault();
   let text = protectCode(markdown, vault);
   text = protectTables(text, vault);
-  text = convertBlocks(text);
-  text = convertInline(text);
+  text = protectSlackMrkdwn(text, vault);
+  text = convertBlocks(text, vault);
+  text = slackifyMarkdown(text);
+  // slackify-markdown は非空入力の末尾へ改行を1つ追加する。
+  if (text.endsWith('\n')) text = text.slice(0, -1);
   text = vault.restore(text);
   return text;
 }

--- a/src/slack.ts
+++ b/src/slack.ts
@@ -15,6 +15,7 @@ import { prefetchSlackHistory } from './slack-history-prefetch.js';
 import { StreamSession } from './stream-session.js';
 import { registerStreamFinalizer } from './stream-finalizer.js';
 import { formatAgentErrorForUser } from './errors.js';
+import { markdownToSlackMrkdwn } from './slack-mrkdwn.js';
 import { addToolHistory, appendToolHistory, formatToolHistoryDisclosure } from './tool-history.js';
 import { ensureSession, getActiveSessionId, getProviderSessionId } from './sessions.js';
 import { createSchedulerRunId } from './scheduler-run.js';
@@ -331,6 +332,8 @@ async function sendSlackResult(
   result: string,
   blocks?: KnownBlock[]
 ): Promise<void> {
+  // Claude出力のMarkdownをSlack mrkdwn記法へ変換してから送信する
+  result = markdownToSlackMrkdwn(result);
   const text = sliceByBytes(result, SLACK_MAX_TEXT_BYTES);
   const textBytes = new TextEncoder().encode(text).length;
   console.log(

--- a/src/slack.ts
+++ b/src/slack.ts
@@ -332,8 +332,8 @@ async function sendSlackResult(
   result: string,
   blocks?: KnownBlock[]
 ): Promise<void> {
-  // Claude出力のMarkdownをSlack mrkdwn記法へ変換してから送信する
-  result = markdownToSlackMrkdwn(result);
+  // result は呼び出し側で mrkdwn へ変換済みの前提（ここでは変換しない）。
+  // 変換は「finalテキスト確定時に一度だけ」行う（冪等でないため二重変換を避ける）。
   const text = sliceByBytes(result, SLACK_MAX_TEXT_BYTES);
   const textBytes = new TextEncoder().encode(text).length;
   console.log(
@@ -545,7 +545,14 @@ export function registerSlackSchedulerBridge(deps: {
       );
 
       const { displayText } = buildAttachmentResult(result, attachments);
-      await sendSlackResult(client, channelId, messageTs, undefined, displayText || '✅', []);
+      await sendSlackResult(
+        client,
+        channelId,
+        messageTs,
+        undefined,
+        markdownToSlackMrkdwn(displayText || '✅'),
+        []
+      );
       return result;
     } catch (error) {
       await client.chat
@@ -1567,6 +1574,8 @@ export async function processMessage(
       extracted.suggestions = fallbackReplySuggestions(replySuggestionCount);
     }
     const { filePaths, displayText } = buildAttachmentResult(extracted.text, structuredAttachments);
+    // finalテキストを mrkdwn へ一度だけ変換し、以降の全描画（本文更新・ボタン付与）で共有する
+    const renderedText = markdownToSlackMrkdwn(displayText || '✅');
     const showToolsButton = toolHistory.length > 0;
     if (showToolsButton) {
       slackToolHistoryByMessageKey.set(slackMessageKey(channelId, messageTs), [...toolHistory]);
@@ -1579,7 +1588,7 @@ export async function processMessage(
     }
 
     // 最終結果を更新（長い場合は分割送信）
-    await sendSlackResult(client, channelId, messageTs, threadTs, displayText || '✅');
+    await sendSlackResult(client, channelId, messageTs, threadTs, renderedText);
 
     // 完了後: StopボタンをNewボタンに切り替え
     // ただしタイムアウト UI ([+5m][⏱ MM:SS]) が表示された直後だと一瞬で
@@ -1596,13 +1605,13 @@ export async function processMessage(
         .update({
           channel: channelId,
           ts: messageTs,
-          text: sliceByBytes(displayText || '✅', SLACK_MAX_TEXT_BYTES),
+          text: sliceByBytes(renderedText, SLACK_MAX_TEXT_BYTES),
           blocks: [
             {
               type: 'section',
               text: {
                 type: 'mrkdwn',
-                text: sliceByBytes(displayText || '✅', SLACK_MAX_TEXT_BYTES),
+                text: sliceByBytes(renderedText, SLACK_MAX_TEXT_BYTES),
               },
             },
             ...createSlackCompletedBlocks({

--- a/src/slack.ts
+++ b/src/slack.ts
@@ -1203,7 +1203,9 @@ export async function startSlackBot(options: SlackChannelOptions): Promise<void>
       });
 
       sessions.set(channelId, newSessionId);
-      await respond({ text: sliceByBytes(result, SLACK_MAX_TEXT_BYTES) });
+      await respond({
+        text: sliceByBytes(markdownToSlackMrkdwn(result), SLACK_MAX_TEXT_BYTES),
+      });
     } catch (error) {
       console.error('[slack] Error:', error);
       await respond({ text: 'エラーが発生しました' });
@@ -1437,7 +1439,9 @@ export async function processMessage(
           view.phase === 'thinking'
             ? `${view.toolLines.length > 0 ? `${view.toolLines.join('\n')}\n\n` : ''}${view.statusLine}`
             : sliceByBytes(
-                appendToolHistory(stripReplySuggestionMarkup(view.text), view.toolLines, ' ▌'),
+                markdownToSlackMrkdwn(
+                  appendToolHistory(stripReplySuggestionMarkup(view.text), view.toolLines, ' ▌')
+                ),
                 SLACK_MAX_TEXT_BYTES
               );
         // 1 秒ごとの chat.update でタイムアウト UI を消さないよう、

--- a/tests/slack-mrkdwn.test.ts
+++ b/tests/slack-mrkdwn.test.ts
@@ -1,0 +1,79 @@
+import { describe, it, expect } from 'vitest';
+import { markdownToSlackMrkdwn } from '../src/slack-mrkdwn.js';
+
+describe('markdownToSlackMrkdwn', () => {
+  it('太字 ** / __ を * へ変換する', () => {
+    expect(markdownToSlackMrkdwn('これは **太字** です')).toBe('これは *太字* です');
+    expect(markdownToSlackMrkdwn('__bold__ text')).toBe('*bold* text');
+  });
+
+  it('斜体 * を _ へ変換する', () => {
+    expect(markdownToSlackMrkdwn('これは *斜体* です')).toBe('これは _斜体_ です');
+  });
+
+  it('太字と斜体が混在しても壊れない', () => {
+    expect(markdownToSlackMrkdwn('**太字**と*斜体*')).toBe('*太字*と_斜体_');
+  });
+
+  it('打ち消し線 ~~ を ~ へ変換する', () => {
+    expect(markdownToSlackMrkdwn('~~消す~~')).toBe('~消す~');
+  });
+
+  it('見出しを太字に変換する', () => {
+    expect(markdownToSlackMrkdwn('# 見出し')).toBe('*見出し*');
+    expect(markdownToSlackMrkdwn('### 小見出し ###')).toBe('*小見出し*');
+  });
+
+  it('リンクを <url|text> へ変換する', () => {
+    expect(markdownToSlackMrkdwn('[Google](https://google.com)')).toBe(
+      '<https://google.com|Google>'
+    );
+  });
+
+  it('画像を <url|alt> へ変換する', () => {
+    expect(markdownToSlackMrkdwn('![alt](https://ex.com/a.png)')).toBe(
+      '<https://ex.com/a.png|alt>'
+    );
+  });
+
+  it('箇条書きを • へ変換する（インデント維持）', () => {
+    expect(markdownToSlackMrkdwn('- 一つ目\n- 二つ目')).toBe('• 一つ目\n• 二つ目');
+    expect(markdownToSlackMrkdwn('  - ネスト')).toBe('  • ネスト');
+  });
+
+  it('水平線を罫線に変換する', () => {
+    expect(markdownToSlackMrkdwn('---')).toBe('──────────');
+  });
+
+  it('インラインコード内は変換しない', () => {
+    expect(markdownToSlackMrkdwn('`**そのまま**`')).toBe('`**そのまま**`');
+  });
+
+  it('フェンスコードブロック内は変換しない', () => {
+    const src = '```js\nconst a = **1**;\n# not heading\n```';
+    expect(markdownToSlackMrkdwn(src)).toBe(src);
+  });
+
+  it('コードブロックの外だけ変換する', () => {
+    const src = '**外**\n```\n**中**\n```\n[x](http://y)';
+    expect(markdownToSlackMrkdwn(src)).toBe('*外*\n```\n**中**\n```\n<http://y|x>');
+  });
+
+  it('表をコードブロックで囲んで整形する', () => {
+    const src = '| A | B |\n|---|---|\n| 1 | 2 |';
+    const out = markdownToSlackMrkdwn(src);
+    expect(out.startsWith('```\n')).toBe(true);
+    expect(out.endsWith('\n```')).toBe(true);
+    expect(out).toContain('A');
+    expect(out).toContain('1');
+    expect(out).toContain('─');
+  });
+
+  it('箇条書きの * を斜体と誤変換しない', () => {
+    expect(markdownToSlackMrkdwn('* 項目')).toBe('• 項目');
+  });
+
+  it('空文字はそのまま返す', () => {
+    expect(markdownToSlackMrkdwn('')).toBe('');
+  });
+});

--- a/tests/slack-mrkdwn.test.ts
+++ b/tests/slack-mrkdwn.test.ts
@@ -1,22 +1,24 @@
 import { describe, it, expect } from 'vitest';
 import { markdownToSlackMrkdwn } from '../src/slack-mrkdwn.js';
 
+const visibleText = (text: string): string => text.replaceAll('\u200B', '');
+
 describe('markdownToSlackMrkdwn', () => {
   it('太字 ** / __ を * へ変換する', () => {
-    expect(markdownToSlackMrkdwn('これは **太字** です')).toBe('これは *太字* です');
-    expect(markdownToSlackMrkdwn('__bold__ text')).toBe('*bold* text');
+    expect(visibleText(markdownToSlackMrkdwn('これは **太字** です'))).toBe('これは *太字* です');
+    expect(visibleText(markdownToSlackMrkdwn('__bold__ text'))).toBe('*bold* text');
   });
 
   it('斜体 * を _ へ変換する', () => {
-    expect(markdownToSlackMrkdwn('これは *斜体* です')).toBe('これは _斜体_ です');
+    expect(visibleText(markdownToSlackMrkdwn('これは *斜体* です'))).toBe('これは _斜体_ です');
   });
 
   it('太字と斜体が混在しても壊れない', () => {
-    expect(markdownToSlackMrkdwn('**太字**と*斜体*')).toBe('*太字*と_斜体_');
+    expect(visibleText(markdownToSlackMrkdwn('**太字**と*斜体*'))).toBe('*太字*と_斜体_');
   });
 
   it('打ち消し線 ~~ を ~ へ変換する', () => {
-    expect(markdownToSlackMrkdwn('~~消す~~')).toBe('~消す~');
+    expect(visibleText(markdownToSlackMrkdwn('~~消す~~'))).toBe('~消す~');
   });
 
   it('見出しを太字に変換する', () => {
@@ -56,7 +58,7 @@ describe('markdownToSlackMrkdwn', () => {
 
   it('コードブロックの外だけ変換する', () => {
     const src = '**外**\n```\n**中**\n```\n[x](http://y)';
-    expect(markdownToSlackMrkdwn(src)).toBe('*外*\n```\n**中**\n```\n<http://y|x>');
+    expect(visibleText(markdownToSlackMrkdwn(src))).toBe('*外*\n```\n**中**\n```\n<http://y|x>');
   });
 
   it('表をコードブロックで囲んで整形する', () => {
@@ -71,6 +73,32 @@ describe('markdownToSlackMrkdwn', () => {
 
   it('箇条書きの * を斜体と誤変換しない', () => {
     expect(markdownToSlackMrkdwn('* 項目')).toBe('• 項目');
+  });
+
+  it('括弧を含むURLを壊さない', () => {
+    expect(
+      markdownToSlackMrkdwn('[wiki](https://en.wikipedia.org/wiki/Function_(mathematics))')
+    ).toBe('<https://en.wikipedia.org/wiki/Function_(mathematics)|wiki>');
+  });
+
+  it('参照形式リンクを変換する', () => {
+    expect(markdownToSlackMrkdwn('[ref][id]\n\n[id]: https://example.com')).toBe(
+      '<https://example.com|ref>'
+    );
+  });
+
+  it('Slackの制御文字をプレーンテキストではエスケープする', () => {
+    expect(markdownToSlackMrkdwn('5 > 3 & 2 < 4')).toBe('5 &gt; 3 &amp; 2 &lt; 4');
+  });
+
+  it('既存のSlackリンク・mention・日付記法を保持する', () => {
+    const src =
+      '<https://example.com|label> <@U123456> <#C123456> <!date^1392734382^{date}|fallback>';
+    expect(markdownToSlackMrkdwn(src)).toBe(src);
+  });
+
+  it('ネストした箇条書きのインデントを保持する', () => {
+    expect(markdownToSlackMrkdwn('- 親\n  - 子\n    - 孫')).toBe('• 親\n  • 子\n    • 孫');
   });
 
   it('空文字はそのまま返す', () => {

--- a/tests/slack-mrkdwn.test.ts
+++ b/tests/slack-mrkdwn.test.ts
@@ -81,6 +81,15 @@ describe('markdownToSlackMrkdwn', () => {
     ).toBe('<https://en.wikipedia.org/wiki/Function_(mathematics)|wiki>');
   });
 
+  it('山括弧で囲まれたリンク先を保持する', () => {
+    expect(markdownToSlackMrkdwn('[Google](<https://google.com>)')).toBe(
+      '<https://google.com|Google>'
+    );
+    expect(
+      markdownToSlackMrkdwn('[wiki](<https://en.wikipedia.org/wiki/Function_(mathematics)>)')
+    ).toBe('<https://en.wikipedia.org/wiki/Function_(mathematics)|wiki>');
+  });
+
   it('参照形式リンクを変換する', () => {
     expect(markdownToSlackMrkdwn('[ref][id]\n\n[id]: https://example.com')).toBe(
       '<https://example.com|ref>'

--- a/tests/slack-reply-mode.test.ts
+++ b/tests/slack-reply-mode.test.ts
@@ -410,9 +410,9 @@ describe('processMessage', () => {
     } as unknown as WebClient;
     const runStream = vi.fn().mockImplementation(async (_prompt, callbacks, _options) => {
       callbacks.onToolUse?.('Bash', { command: 'pwd' });
-      callbacks.onText?.('ok', 'ok');
-      callbacks.onComplete?.({ result: 'ok', sessionId: 'provider-1' });
-      return { result: 'ok', sessionId: 'provider-1' };
+      callbacks.onText?.('**ok**', '**ok**');
+      callbacks.onComplete?.({ result: '**ok**', sessionId: 'provider-1' });
+      return { result: '**ok**', sessionId: 'provider-1' };
     });
     const agentRunner = {
       runStream,
@@ -454,7 +454,7 @@ describe('processMessage', () => {
       text?: string;
       blocks?: Array<{ type?: string; elements?: Array<{ action_id?: string }> }>;
     };
-    expect(lastUpdate.text).toBe('ok');
+    expect(lastUpdate.text?.replaceAll('\u200B', '')).toBe('*ok*');
     expect(lastUpdate.text).not.toContain('Bash実行');
     expect(
       lastUpdate.blocks?.some((block) =>

--- a/tests/slack-scheduler-bridge.test.ts
+++ b/tests/slack-scheduler-bridge.test.ts
@@ -41,7 +41,10 @@ describe('registerSlackSchedulerBridge', () => {
       runStream: vi.fn(async (_prompt, callbacks) => {
         callbacks.onToolUse?.('Read', { file_path: 'skills/xs-example/SKILL.md' });
         callbacks.onToolUse?.('Bash', { command: 'uv run example.py' });
-        const result = { result: 'done', sessionId: 'provider-1' };
+        const result = {
+          result: '**done** [Docs](https://example.com)',
+          sessionId: 'provider-1',
+        };
         callbacks.onComplete?.(result);
         return result;
       }),
@@ -57,7 +60,7 @@ describe('registerSlackSchedulerBridge', () => {
 
     const result = await runner?.('trigger payload', 'C123');
 
-    expect(result).toBe('done');
+    expect(result).toBe('**done** [Docs](https://example.com)');
     expect(postMessage).toHaveBeenCalledWith({
       channel: 'C123',
       text: '🤔 考え中...',
@@ -75,12 +78,21 @@ describe('registerSlackSchedulerBridge', () => {
         appSessionId: expect.stringMatching(/^scheduler-run-slack-/),
       })
     );
-    expect(update).toHaveBeenCalledWith({
+    const completedPayload = update.mock.calls.at(-1)?.[0] as {
+      channel: string;
+      ts: string;
+      text: string;
+      blocks: unknown[];
+    };
+    expect(completedPayload).toEqual({
       channel: 'C123',
       ts: '1700000000.000100',
-      text: 'done',
+      text: expect.any(String),
       blocks: [],
     });
+    expect(completedPayload.text.replaceAll('\u200B', '')).toBe(
+      '*done* <https://example.com|Docs>'
+    );
 
     const activity = await import('../src/activity-store.js');
     const snapshot = activity.getActivity('slack-schedule:C123');


### PR DESCRIPTION
## 概要

エージェントの出力に含まれる Markdown が、Slack ではそのまま生の記号として表示されてしまう問題を解消します。送信直前に Slack の mrkdwn 記法へ変換することで、太字・箇条書き・リンク・表などが Slack 上で正しく整形表示されます。

（xangi は Claude Code / Codex / Cursor / Grok / Antigravity など複数エージェントに対応しており、本変換は出力元のエージェントを問わず Slack 送信経路で一律に適用されます。）

## 変更内容

- Markdown → Slack mrkdwn 変換
  - `slackify-markdown` を使い、Markdownを正規表現だけで解釈しない構成へ変更
  - 太字 / 斜体 / 打ち消し / 見出し / リンク / 参照形式リンク / 箇条書きなどを変換
  - CommonMarkの山括弧付きリンク先 `[text](<url>)` を正規化し、URLが失われないように修正
  - プレーンテキストの `&` / `<` / `>` をSlack仕様に従ってエスケープ
  - 既存のSlackリンク・mention・日付記法、コード片を変換対象から保護
  - 表は従来どおり等幅整形してコードブロックで囲む
  - ネストした箇条書きのインデントを維持
- 送信経路への組み込み
  - 通常応答のストリーミング表示と最終表示
  - スケジューラ / trigger 経由のエージェント応答
  - `/skill` コマンドの応答
  - 最終テキスト確定後の本文更新と完了ボタン付与で同じ変換済みテキストを共有

## テスト

- 変換ユニットテスト21件
  - 括弧を含むURL、山括弧付きリンク先、参照形式リンク、Slack制御文字、既存Slack記法、3階層箇条書きを含む
- 通常応答・スケジューラ経路の統合テストを追加
- 対象テスト53件、lint、format check、typecheck、build 成功
- Slack実機で太字・斜体・取消・箇条書き・表・インラインコード・比較式を確認
- 山括弧付き通常URL・括弧URLは修正後の再確認待ち
- CI全件回帰は最新commitで確認