### PR TITLE
fix: Agyのworkspace書き込み時のartifact誤判定を自動回復する

### DIFF
--- a/src/antigravity-cli.ts
+++ b/src/antigravity-cli.ts
@@ -1,6 +1,7 @@
 import type { RunOptions, RunResult, StreamCallbacks } from './agent-runner.js';
 import {
   extractAntigravityErrorMessage,
+  isAntigravityWorkspaceArtifactPathError,
   reportsUnsupportedOutputFormat,
 } from './antigravity-output.js';
 import { buildSystemPrompt } from './base-runner.js';
@@ -88,10 +89,28 @@ type StreamOutputCapability = 'unknown' | 'stream-json' | 'legacy';
 type SlashCommandCapabilityProbeResult = 'supported' | 'unsupported' | 'unknown';
 
 const CAPABILITY_PROBE_TIMEOUT_MS = 5_000;
+const WORKSPACE_WRITE_SYSTEM_GUIDANCE = `## Antigravity workspace file writes
+When calling write_to_file for a normal file in the current workspace, omit ArtifactMetadata entirely. ArtifactMetadata is reserved for Antigravity's internal artifact directory, not workspace files.`;
+const WORKSPACE_WRITE_RECOVERY_PROMPT = `The preceding write_to_file call failed because ArtifactMetadata was attached to a normal workspace path. Continue the same task from that failed write only. Retry that write without the ArtifactMetadata field and preserve the requested workspace path. Do not repeat completed tool calls or external side effects. Then finish the task normally.`;
 
 interface AntigravityOutputError extends Error {
   antigravityStdout?: string;
   antigravityStderr?: string;
+}
+
+interface AntigravityAttemptOptions {
+  recordPrompt?: boolean;
+}
+
+class AntigravityConversationError extends Error {
+  constructor(
+    message: string,
+    readonly conversationId?: string,
+    options?: ErrorOptions
+  ) {
+    super(message, options);
+    this.name = 'AntigravityConversationError';
+  }
 }
 
 export class AntigravityRunner extends CliRunnerBase {
@@ -113,7 +132,9 @@ export class AntigravityRunner extends CliRunnerBase {
 
   constructor(options?: AntigravityOptions) {
     super(options);
-    this.systemPrompt = buildSystemPrompt(options?.platform);
+    this.systemPrompt = [buildSystemPrompt(options?.platform), WORKSPACE_WRITE_SYSTEM_GUIDANCE]
+      .filter(Boolean)
+      .join('\n\n');
     this.printTimeout =
       process.env.ANTIGRAVITY_PRINT_TIMEOUT || `${Math.ceil(this.timeoutMs / 1000)}s`;
     this.disableSlashCommands = process.env.ANTIGRAVITY_DISABLE_SLASH_COMMANDS !== 'false';
@@ -336,11 +357,36 @@ export class AntigravityRunner extends CliRunnerBase {
   }
 
   async run(prompt: string, options?: RunOptions): Promise<RunResult> {
+    try {
+      return await this.runOnce(prompt, options);
+    } catch (error) {
+      const conversationId = this.getWorkspaceWriteRecoveryConversationId(error, options);
+      if (!conversationId) throw error;
+
+      console.warn(
+        `[antigravity] Retrying failed workspace write without ArtifactMetadata in conversation ${conversationId.slice(0, 8)}...`
+      );
+      return this.runOnce(
+        WORKSPACE_WRITE_RECOVERY_PROMPT,
+        {
+          ...options,
+          sessionId: conversationId,
+        },
+        { recordPrompt: false }
+      );
+    }
+  }
+
+  private async runOnce(
+    prompt: string,
+    options?: RunOptions,
+    attemptOptions: AntigravityAttemptOptions = {}
+  ): Promise<RunResult> {
     const fullPrompt = this.buildFullPrompt(prompt);
 
     this.logExecution('Executing', options);
 
-    if (options?.appSessionId && this.workdir) {
+    if (attemptOptions.recordPrompt !== false && options?.appSessionId && this.workdir) {
       logPrompt(this.workdir, options.appSessionId, fullPrompt);
     }
 
@@ -360,8 +406,18 @@ export class AntigravityRunner extends CliRunnerBase {
     } catch (error) {
       const outputError = error as AntigravityOutputError;
       const errorJson = this.parseResponse(outputError.antigravityStdout ?? '');
-      if (this.isErrorStatus(errorJson)) {
+      if (errorJson?.status === 'ERROR') {
         this.outputCapability = 'json';
+        const detail =
+          this.extractErrorMessage(errorJson) ??
+          (error instanceof Error ? error.message : String(error));
+        if (isAntigravityWorkspaceArtifactPathError(detail)) {
+          throw new AntigravityConversationError(
+            detail,
+            errorJson?.conversation_id ?? options?.sessionId,
+            { cause: error }
+          );
+        }
         throw error;
       }
 
@@ -398,14 +454,57 @@ export class AntigravityRunner extends CliRunnerBase {
     callbacks: StreamCallbacks,
     options?: RunOptions
   ): Promise<RunResult> {
+    try {
+      return await this.runStreamOnce(prompt, callbacks, options);
+    } catch (error) {
+      const conversationId = this.getWorkspaceWriteRecoveryConversationId(error, options);
+      if (conversationId) {
+        console.warn(
+          `[antigravity] Continuing failed workspace write without ArtifactMetadata in conversation ${conversationId.slice(0, 8)}...`
+        );
+        const recoveryCallbacks: StreamCallbacks = {
+          ...callbacks,
+          // The first stream already announced readiness before returning its result error.
+          onBackendReady: undefined,
+        };
+        try {
+          return await this.runStreamOnce(
+            WORKSPACE_WRITE_RECOVERY_PROMPT,
+            recoveryCallbacks,
+            {
+              ...options,
+              sessionId: conversationId,
+            },
+            { recordPrompt: false }
+          );
+        } catch (recoveryError) {
+          const err =
+            recoveryError instanceof Error ? recoveryError : new Error(String(recoveryError));
+          callbacks.onError?.(err);
+          throw recoveryError;
+        }
+      }
+
+      const err = error instanceof Error ? error : new Error(String(error));
+      callbacks.onError?.(err);
+      throw error;
+    }
+  }
+
+  private async runStreamOnce(
+    prompt: string,
+    callbacks: StreamCallbacks,
+    options?: RunOptions,
+    attemptOptions: AntigravityAttemptOptions = {}
+  ): Promise<RunResult> {
     if (this.streamOutputCapability === 'legacy') {
-      return this.runPseudoStream(prompt, callbacks, options);
+      return this.runPseudoStream(prompt, callbacks, options, attemptOptions);
     }
 
     const fullPrompt = this.buildFullPrompt(prompt);
     this.logExecution('Streaming', options);
 
-    if (options?.appSessionId && this.workdir) {
+    if (attemptOptions.recordPrompt !== false && options?.appSessionId && this.workdir) {
       logPrompt(this.workdir, options.appSessionId, fullPrompt);
     }
 
@@ -447,13 +546,16 @@ export class AntigravityRunner extends CliRunnerBase {
         const fallbackOptions = options?.appSessionId
           ? { ...options, appSessionId: undefined }
           : options;
-        const result = await this.runPseudoStream(prompt, callbacks, fallbackOptions);
+        const result = await this.runPseudoStream(
+          prompt,
+          callbacks,
+          fallbackOptions,
+          attemptOptions
+        );
         onComplete(result);
         return result;
       }
 
-      const err = error instanceof Error ? error : new Error(String(error));
-      callbacks.onError?.(err);
       throw error;
     }
   }
@@ -535,7 +637,13 @@ export class AntigravityRunner extends CliRunnerBase {
 
           if (result.status === 'ERROR') {
             errorDetail = this.extractErrorMessage(result) ?? 'Antigravity CLI returned ERROR';
-            return phase === 'stream' ? new Error(errorDetail) : undefined;
+            // Wait for Agy to close before starting the recovery process for this known error.
+            // Starting it directly from the data event would overlap two managed processes for
+            // the same channel and could corrupt cancellation/timeout ownership.
+            if (isAntigravityWorkspaceArtifactPathError(errorDetail)) return undefined;
+            return phase === 'stream'
+              ? new AntigravityConversationError(errorDetail, sessionId)
+              : undefined;
           }
           if (result.status !== 'SUCCESS') {
             errorDetail = `Antigravity CLI returned unknown stream status${
@@ -548,6 +656,7 @@ export class AntigravityRunner extends CliRunnerBase {
           if (!response) {
             errorDetail =
               lastToolError ?? 'Antigravity CLI returned SUCCESS JSON without a response';
+            if (isAntigravityWorkspaceArtifactPathError(errorDetail)) return undefined;
             return phase === 'stream' ? new Error(errorDetail) : undefined;
           }
 
@@ -577,7 +686,7 @@ export class AntigravityRunner extends CliRunnerBase {
           throw new Error('Antigravity CLI stream ended without a result event');
         }
         if (errorDetail) {
-          throw new Error(errorDetail);
+          throw new AntigravityConversationError(errorDetail, sessionId);
         }
         return { result: fullText, sessionId };
       },
@@ -588,18 +697,13 @@ export class AntigravityRunner extends CliRunnerBase {
   private async runPseudoStream(
     prompt: string,
     callbacks: StreamCallbacks,
-    options?: RunOptions
+    options?: RunOptions,
+    attemptOptions: AntigravityAttemptOptions = {}
   ): Promise<RunResult> {
-    try {
-      const result = await this.run(prompt, options);
-      callbacks.onText?.(result.result, result.result);
-      callbacks.onComplete?.(result);
-      return result;
-    } catch (error) {
-      const err = error instanceof Error ? error : new Error(String(error));
-      callbacks.onError?.(err);
-      throw error;
-    }
+    const result = await this.runOnce(prompt, options, attemptOptions);
+    callbacks.onText?.(result.result, result.result);
+    callbacks.onComplete?.(result);
+    return result;
   }
 
   private interpretOutput(
@@ -637,7 +741,10 @@ export class AntigravityRunner extends CliRunnerBase {
         return { result, sessionId: response.conversation_id ?? priorSessionId ?? '' };
       }
       if (response.status === 'ERROR') {
-        throw new Error(this.extractErrorMessage(response) ?? 'Antigravity CLI returned ERROR');
+        throw new AntigravityConversationError(
+          this.extractErrorMessage(response) ?? 'Antigravity CLI returned ERROR',
+          response.conversation_id ?? priorSessionId
+        );
       }
       throw new Error(
         `Antigravity CLI returned unknown JSON status${response.status ? `: ${response.status}` : ''}`
@@ -697,10 +804,6 @@ export class AntigravityRunner extends CliRunnerBase {
     return this.extractErrorMessage(response) ?? 'Antigravity CLI returned ERROR';
   }
 
-  private isErrorStatus(response: AntigravityJsonResponse | null): boolean {
-    return response?.status === 'ERROR';
-  }
-
   private isUnsupportedOutputFormat(error: unknown): boolean {
     const outputError = error as AntigravityOutputError;
     const detail = [
@@ -711,6 +814,17 @@ export class AntigravityRunner extends CliRunnerBase {
       .filter(Boolean)
       .join('\n');
     return reportsUnsupportedOutputFormat(detail);
+  }
+
+  private getWorkspaceWriteRecoveryConversationId(
+    error: unknown,
+    options?: RunOptions
+  ): string | undefined {
+    if (!isAntigravityWorkspaceArtifactPathError(error)) return undefined;
+    if (error instanceof AntigravityConversationError && error.conversationId) {
+      return error.conversationId;
+    }
+    return options?.sessionId;
   }
 
   private looksLikeNativeJsonEnvelope(output: string): boolean {

--- a/src/antigravity-cli.ts
+++ b/src/antigravity-cli.ts
@@ -691,6 +691,10 @@ export class AntigravityRunner extends CliRunnerBase {
         return { result: fullText, sessionId };
       },
       exitErrorDetail: () => errorDetail,
+      wrapExitError: (error) =>
+        sessionId && isAntigravityWorkspaceArtifactPathError(error)
+          ? new AntigravityConversationError(error.message, sessionId, { cause: error })
+          : error,
     };
   }
 

--- a/src/antigravity-output.ts
+++ b/src/antigravity-output.ts
@@ -57,3 +57,12 @@ export function reportsUnsupportedOutputFormat(detail: string): boolean {
     /(?:option|flag|argument)s?\s+(?:is|are)\s+not\s+defined/i.test(detail);
   return mentionsOutputFormat && reportsUnsupported;
 }
+
+export function isAntigravityWorkspaceArtifactPathError(error: unknown): boolean {
+  const detail = error instanceof Error ? error.message : String(error);
+  return (
+    /write_to_file/i.test(detail) &&
+    /is not a valid artifact path/i.test(detail) &&
+    /artifacts must be in/i.test(detail)
+  );
+}

--- a/src/cli-runner-core.ts
+++ b/src/cli-runner-core.ts
@@ -36,6 +36,8 @@ export interface CliStreamParser {
   finalize(): { result: string; sessionId: string };
   /** exit code != 0 のとき、エラーメッセージに添える詳細（CLI の error イベント本文など） */
   exitErrorDetail?(): string | undefined;
+  /** exit code != 0 のエラーへ、ランナー固有の状態を引き継ぐ */
+  wrapExitError?(error: Error): Error;
 }
 
 export interface ExecuteStreamOptions {
@@ -315,7 +317,8 @@ export abstract class CliRunnerBase extends EventEmitter implements AgentRunner 
         if (fatalError) return; // 既に reject 済み
 
         if (code !== 0) {
-          const error = this.buildExitError(code, parser.exitErrorDetail?.(), stderr);
+          const exitError = this.buildExitError(code, parser.exitErrorDetail?.(), stderr);
+          const error = parser.wrapExitError?.(exitError) ?? exitError;
           notifyError(error);
           reject(error);
           return;

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -1,3 +1,5 @@
+import { isAntigravityWorkspaceArtifactPathError } from './antigravity-output.js';
+
 /**
  * クライアント入力に起因するエラー（パラメータ不足・バリデーション失敗など）。
  * tool-server側でこの型を投げると HTTP 400 で返る。それ以外は 500（サーバー内部エラー）。
@@ -42,6 +44,7 @@ export type AgentErrorKind =
   | 'crash' // AI プロセスの予期しない終了
   | 'circuit-breaker' // 連続クラッシュによる一時停止
   | 'usage-limit' // バックエンドの利用上限到達（時間経過で回復）
+  | 'antigravity-artifact-path' // Agy が通常ファイルを内部 artifact と誤分類
   | 'unknown';
 
 const CANCEL_MESSAGE = 'Request cancelled by user';
@@ -50,6 +53,7 @@ const CANCEL_MESSAGE = 'Request cancelled by user';
 export function classifyAgentError(error: unknown): AgentErrorKind {
   const msg = error instanceof Error ? error.message : String(error);
   if (msg === CANCEL_MESSAGE) return 'cancelled';
+  if (isAntigravityWorkspaceArtifactPathError(error)) return 'antigravity-artifact-path';
   if (msg.includes('timed out')) return 'timeout';
   if (msg.includes('Process exited unexpectedly')) return 'crash';
   if (msg.includes('Circuit breaker')) return 'circuit-breaker';
@@ -77,6 +81,8 @@ export function formatAgentErrorForUser(error: unknown, opts?: { timeoutMs?: num
       return '🔌 AIプロセスが連続でクラッシュしたため一時停止中です。しばらくしてから再試行してください';
     case 'usage-limit':
       return `💳 バックエンドの利用上限に達しています: ${detail}`;
+    case 'antigravity-artifact-path':
+      return '❌ Agyがワークスペースへの書き込みを内部artifactと誤判定しました。自動回復にも失敗したため、もう一度お試しください';
     case 'unknown':
     default:
       return `❌ エラーが発生しました: ${detail}`;

--- a/tests/antigravity-cli.test.ts
+++ b/tests/antigravity-cli.test.ts
@@ -43,6 +43,11 @@ vi.mock('fs', async () => {
   };
 });
 
+vi.mock('../src/transcript-logger.js', () => ({
+  logPrompt: vi.fn(),
+  logResponse: vi.fn(),
+}));
+
 const tick = () => new Promise((resolve) => setTimeout(resolve, 20));
 
 describe('AntigravityRunner', () => {
@@ -307,6 +312,15 @@ describe('AntigravityRunner', () => {
     expect(args[args.indexOf('--output-format') + 1]).toBe('json');
   });
 
+  it('instructs Agy to omit ArtifactMetadata for ordinary workspace writes', async () => {
+    const runner = new AntigravityRunner({});
+    const { args } = await getSpawnArgs(runner, 'run');
+    const prompt = args[args.indexOf('-p') + 1];
+
+    expect(prompt).toContain('omit ArtifactMetadata entirely');
+    expect(prompt).toContain('not workspace files');
+  });
+
   it('allows overriding the Antigravity print timeout', async () => {
     process.env.ANTIGRAVITY_PRINT_TIMEOUT = '30s';
     const runner = new AntigravityRunner({});
@@ -490,6 +504,118 @@ describe('AntigravityRunner', () => {
 
     await expect(promise).rejects.toThrow('auth failed');
     expect(spawn).toHaveBeenCalledTimes(1);
+  });
+
+  it('continues a failed workspace write once in the same JSON conversation', async () => {
+    const { spawn } = await import('child_process');
+    const { logPrompt, logResponse } = await import('../src/transcript-logger.js');
+    vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+    const runner = new AntigravityRunner({ workdir: '/tmp/project' });
+    const promise = runner.run('write the daily memory', { appSessionId: 'app-session' });
+    let mockProcess = await waitForProcess();
+    const artifactError =
+      'declaring permissions: cortex tool write_to_file: /workspace/memory.md is not a valid artifact path; artifacts must be in /home/user/.gemini/antigravity-cli/brain/conv-write/';
+
+    mockProcess.stdout.emit(
+      'data',
+      Buffer.from(
+        JSON.stringify({
+          status: 'ERROR',
+          conversation_id: 'conv-write',
+          error: artifactError,
+        })
+      )
+    );
+    mockProcess.emit('close', 0);
+
+    mockProcess = await waitForProcess(2);
+    const recoveryArgs = (spawn as ReturnType<typeof vi.fn>).mock.calls[1][1] as string[];
+    expect(recoveryArgs[recoveryArgs.indexOf('--conversation') + 1]).toBe('conv-write');
+    const recoveryPrompt = recoveryArgs[recoveryArgs.indexOf('-p') + 1];
+    expect(recoveryPrompt).toContain('Retry that write without the ArtifactMetadata field');
+    expect(recoveryPrompt).not.toContain('write the daily memory');
+
+    mockProcess.stdout.emit('data', Buffer.from(success('memory written', 'conv-write')));
+    mockProcess.emit('close', 0);
+
+    await expect(promise).resolves.toEqual({ result: 'memory written', sessionId: 'conv-write' });
+    expect(spawn).toHaveBeenCalledTimes(2);
+    expect(logPrompt).toHaveBeenCalledTimes(1);
+    expect(logPrompt).toHaveBeenCalledWith(
+      '/tmp/project',
+      'app-session',
+      expect.stringContaining('write the daily memory')
+    );
+    expect(logResponse).toHaveBeenCalledOnce();
+  });
+
+  it('continues artifact-path ERROR JSON after a non-zero process exit', async () => {
+    const { spawn } = await import('child_process');
+    vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+    const runner = new AntigravityRunner({});
+    const promise = runner.run('write the daily memory');
+    const artifactError =
+      'write_to_file: /workspace/memory.md is not a valid artifact path; artifacts must be in /brain/conv-write/';
+
+    let mockProcess = await waitForProcess();
+    mockProcess.stdout.emit(
+      'data',
+      Buffer.from(
+        JSON.stringify({
+          status: 'ERROR',
+          conversation_id: 'conv-write',
+          error: artifactError,
+        })
+      )
+    );
+    mockProcess.emit('close', 1);
+
+    mockProcess = await waitForProcess(2);
+    const recoveryArgs = (spawn as ReturnType<typeof vi.fn>).mock.calls[1][1] as string[];
+    expect(recoveryArgs[recoveryArgs.indexOf('--conversation') + 1]).toBe('conv-write');
+    mockProcess.stdout.emit('data', Buffer.from(success('memory written', 'conv-write')));
+    mockProcess.emit('close', 0);
+
+    await expect(promise).resolves.toEqual({ result: 'memory written', sessionId: 'conv-write' });
+    expect(spawn).toHaveBeenCalledTimes(2);
+  });
+
+  it('does not repeat workspace write recovery after the continuation fails', async () => {
+    const { spawn } = await import('child_process');
+    vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+    const runner = new AntigravityRunner({});
+    const promise = runner.run('write the daily memory');
+    const artifactError =
+      'write_to_file: /workspace/memory.md is not a valid artifact path; artifacts must be in /brain/conv-write/';
+
+    let mockProcess = await waitForProcess();
+    mockProcess.stdout.emit(
+      'data',
+      Buffer.from(
+        JSON.stringify({
+          status: 'ERROR',
+          conversation_id: 'conv-write',
+          error: artifactError,
+        })
+      )
+    );
+    mockProcess.emit('close', 0);
+
+    mockProcess = await waitForProcess(2);
+    mockProcess.stdout.emit(
+      'data',
+      Buffer.from(
+        JSON.stringify({
+          status: 'ERROR',
+          conversation_id: 'conv-write',
+          error: artifactError,
+        })
+      )
+    );
+    mockProcess.emit('close', 0);
+
+    await expect(promise).rejects.toThrow('is not a valid artifact path');
+    expect(spawn).toHaveBeenCalledTimes(2);
   });
 
   it('fails safely for an unknown JSON status', async () => {
@@ -791,6 +917,89 @@ describe('AntigravityRunner', () => {
 
     await expect(promise).rejects.toThrow('invalid model');
     expect(onError).toHaveBeenCalledTimes(1);
+  });
+
+  it('continues a failed streamed workspace write in the same conversation', async () => {
+    const { spawn } = await import('child_process');
+    const { logPrompt, logResponse } = await import('../src/transcript-logger.js');
+    vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+    const runner = new AntigravityRunner({ workdir: '/tmp/project' });
+    const onBackendReady = vi.fn();
+    const onText = vi.fn();
+    const onComplete = vi.fn();
+    const onError = vi.fn();
+    const promise = runner.runStream(
+      'write the daily memory',
+      {
+        onBackendReady,
+        onText,
+        onComplete,
+        onError,
+      },
+      { appSessionId: 'app-session' }
+    );
+    const artifactError =
+      'declaring permissions: cortex tool write_to_file: /workspace/memory.md is not a valid artifact path; artifacts must be in /brain/conv-stream-write/';
+
+    let mockProcess = await waitForProcess();
+    mockProcess.stdout.emit(
+      'data',
+      Buffer.from(
+        `${JSON.stringify({
+          event: 'init',
+          conversation_id: 'conv-stream-write',
+          init: {},
+        })}\n${JSON.stringify({
+          event: 'result',
+          result: {
+            conversation_id: 'conv-stream-write',
+            status: 'ERROR',
+            response: '',
+            error: artifactError,
+          },
+        })}\n`
+      )
+    );
+    mockProcess.emit('close', 0);
+
+    mockProcess = await waitForProcess(2);
+    const recoveryArgs = (spawn as ReturnType<typeof vi.fn>).mock.calls[1][1] as string[];
+    expect(recoveryArgs[recoveryArgs.indexOf('--conversation') + 1]).toBe('conv-stream-write');
+    mockProcess.stdout.emit(
+      'data',
+      Buffer.from(
+        `${JSON.stringify({
+          event: 'init',
+          conversation_id: 'conv-stream-write',
+          init: {},
+        })}\n${JSON.stringify({
+          event: 'result',
+          result: {
+            conversation_id: 'conv-stream-write',
+            status: 'SUCCESS',
+            response: 'memory written',
+          },
+        })}\n`
+      )
+    );
+    mockProcess.emit('close', 0);
+
+    await expect(promise).resolves.toEqual({
+      result: 'memory written',
+      sessionId: 'conv-stream-write',
+    });
+    expect(onBackendReady).toHaveBeenCalledTimes(1);
+    expect(onText).toHaveBeenCalledWith('memory written', 'memory written');
+    expect(onComplete).toHaveBeenCalledTimes(1);
+    expect(onError).not.toHaveBeenCalled();
+    expect(spawn).toHaveBeenCalledTimes(2);
+    expect(logPrompt).toHaveBeenCalledTimes(1);
+    expect(logPrompt).toHaveBeenCalledWith(
+      '/tmp/project',
+      'app-session',
+      expect.stringContaining('write the daily memory')
+    );
+    expect(logResponse).toHaveBeenCalledOnce();
   });
 
   it('recovers a new sessionId from Agy 1.1.2 plain output without re-running', async () => {

--- a/tests/antigravity-cli.test.ts
+++ b/tests/antigravity-cli.test.ts
@@ -1002,6 +1002,66 @@ describe('AntigravityRunner', () => {
     expect(logResponse).toHaveBeenCalledOnce();
   });
 
+  it('continues a streamed workspace write after a non-zero process exit', async () => {
+    const { spawn } = await import('child_process');
+    vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+    const runner = new AntigravityRunner({});
+    const onError = vi.fn();
+    const promise = runner.runStream('write the daily memory', { onError });
+    const artifactError =
+      'write_to_file: /workspace/memory.md is not a valid artifact path; artifacts must be in /brain/conv-stream-write/';
+
+    let mockProcess = await waitForProcess();
+    mockProcess.stdout.emit(
+      'data',
+      Buffer.from(
+        `${JSON.stringify({
+          event: 'init',
+          conversation_id: 'conv-stream-write',
+          init: {},
+        })}\n${JSON.stringify({
+          event: 'result',
+          result: {
+            conversation_id: 'conv-stream-write',
+            status: 'ERROR',
+            response: '',
+            error: artifactError,
+          },
+        })}\n`
+      )
+    );
+    mockProcess.emit('close', 1);
+
+    mockProcess = await waitForProcess(2);
+    const recoveryArgs = (spawn as ReturnType<typeof vi.fn>).mock.calls[1][1] as string[];
+    expect(recoveryArgs[recoveryArgs.indexOf('--conversation') + 1]).toBe('conv-stream-write');
+    mockProcess.stdout.emit(
+      'data',
+      Buffer.from(
+        `${JSON.stringify({
+          event: 'init',
+          conversation_id: 'conv-stream-write',
+          init: {},
+        })}\n${JSON.stringify({
+          event: 'result',
+          result: {
+            conversation_id: 'conv-stream-write',
+            status: 'SUCCESS',
+            response: 'memory written',
+          },
+        })}\n`
+      )
+    );
+    mockProcess.emit('close', 0);
+
+    await expect(promise).resolves.toEqual({
+      result: 'memory written',
+      sessionId: 'conv-stream-write',
+    });
+    expect(onError).not.toHaveBeenCalled();
+    expect(spawn).toHaveBeenCalledTimes(2);
+  });
+
   it('recovers a new sessionId from Agy 1.1.2 plain output without re-running', async () => {
     const { spawn } = await import('child_process');
     const home = mkdtempSync(join(tmpdir(), 'agy-home-'));

--- a/tests/errors-classify.test.ts
+++ b/tests/errors-classify.test.ts
@@ -15,6 +15,10 @@ describe('classifyAgentError', () => {
     ['Circuit breaker OPEN. Rejecting all queued requests.', 'circuit-breaker'],
     ["Codex CLI exited with code 1: You've hit your usage limit. Upgrade to Pro", 'usage-limit'],
     ["Error: You've hit your limit · resets 1pm (Asia/Tokyo)", 'usage-limit'],
+    [
+      'declaring permissions: cortex tool write_to_file: /workspace/a.md is not a valid artifact path; artifacts must be in /home/user/.gemini/antigravity-cli/brain/conv/',
+      'antigravity-artifact-path',
+    ],
     ['Something completely different', 'unknown'],
   ])('%s → %s', (message, expected) => {
     expect(classifyAgentError(new Error(message))).toBe(expected);
@@ -49,6 +53,16 @@ describe('formatAgentErrorForUser', () => {
     expect(msg.length).toBeLessThan(250);
     expect(msg).toContain('❌');
   });
+
+  it('Agyのartifact誤判定は再試行を促す専用メッセージ', () => {
+    const msg = formatAgentErrorForUser(
+      new Error(
+        'write_to_file: /workspace/a.md is not a valid artifact path; artifacts must be in /brain/'
+      )
+    );
+    expect(msg).toContain('Agy');
+    expect(msg).toContain('自動回復');
+  });
 });
 
 describe('shouldSendErrorFollowUp', () => {
@@ -57,6 +71,10 @@ describe('shouldSendErrorFollowUp', () => {
     ['Circuit breaker OPEN', false],
     ["You've hit your usage limit", false],
     ['Request cancelled by user', false],
+    [
+      'write_to_file: /workspace/a.md is not a valid artifact path; artifacts must be in /brain/',
+      false,
+    ],
     ['Process exited unexpectedly with code 143', true],
     ['Some random error', true],
   ])('%s → %s', (message, expected) => {


### PR DESCRIPTION
## 概要

Agyで通常のworkspaceファイルへ`write_to_file`を実行する際、モデルが`ArtifactMetadata`を付与すると、workspace内のパスが内部artifact用パスではないとして処理が失敗することがあります。

このPRでは、Agyバックエンドに限定して誤った`ArtifactMetadata`付与を予防し、既知のエラーが発生した場合は同じconversationで失敗した書き込みから一度だけ安全に継続します。

関連するAgy側のissue: https://github.com/google-antigravity/antigravity-cli/issues/838

## 変更内容

- 通常のworkspace書き込みでは`ArtifactMetadata`を付与しないようAgy専用system contextへ指示を追加
- `write_to_file`のartifact path誤判定エラーを厳密なメッセージ条件で検出
- JSON実行とstream-json実行の両方でconversation IDを保持
- 同じconversationへ内部継続プロンプトを送り、失敗した書き込みを一度だけ再試行
- 元のユーザー依頼や完了済みツール、外部副作用を再実行しないよう回復指示を制限
- streamでは最初のAgyプロセス終了を待ってから回復し、同一チャンネルのプロセス管理競合を防止
- 自動回復後も同じエラーになった場合は再試行せず、専用エラーとしてユーザーへ通知
- 内部リカバリ指示をtranscriptのユーザー発言として記録せず、元の依頼と最終回答だけを保持

## 互換性と安全性

- 回復処理はAgyランナー内だけで動作し、他のバックエンドには影響しません
- artifact誤判定を示す既知の3条件が一致した場合だけ回復します
- 回復は最大1回で、元のタスク全体を再実行しません
- 旧Agyのlegacy出力フォールバックは従来どおり維持されます

## 確認

- `npx vitest run tests/antigravity-cli.test.ts tests/errors-classify.test.ts`（70 tests passed）
- `npm run typecheck`
- `npm run lint`
- `npm run format:check`
- `git diff --check`