### PR TITLE
antigravityのセットアップ手順を修正

### DIFF
--- a/src/setup/guided-onboarding.ts
+++ b/src/setup/guided-onboarding.ts
@@ -380,15 +380,19 @@ export function buildGuidedLaunchArgs(
   prompt: string,
   env: NodeJS.ProcessEnv = process.env
 ): string[] {
-  if (selected.id !== 'opencode') return [prompt];
-  return [
-    'run',
-    '--auto',
-    '--agent',
-    'build',
-    ...(env.AGENT_MODEL ? ['--model', env.AGENT_MODEL] : []),
-    prompt,
-  ];
+  if (selected.id === 'opencode') {
+    return [
+      'run',
+      '--auto',
+      '--agent',
+      'build',
+      ...(env.AGENT_MODEL ? ['--model', env.AGENT_MODEL] : []),
+      prompt,
+    ];
+  } else if (selected.id === 'antigravity') {
+    return ['-i', prompt];
+  }
+  return [prompt];
 }
 
 async function defaultLaunchGuidedBackend(

--- a/tests/guided-onboarding.test.ts
+++ b/tests/guided-onboarding.test.ts
@@ -53,6 +53,18 @@ describe('guided setup backend preflight', () => {
     ]);
   });
 
+  it('launches Antigravity with an interactive initial prompt', () => {
+    const backend = {
+      id: 'antigravity' as const,
+      label: 'Antigravity',
+      command: 'agy',
+      executable: '/usr/local/bin/agy',
+      version: '1.1.22',
+      authGuide: 'agyを初回起動して認証',
+    };
+    expect(buildGuidedLaunchArgs(backend, 'setup prompt')).toEqual(['-i', 'setup prompt']);
+  });
+
   it('detects only executable supported agent CLIs and records versions', async () => {
     const executable = new Set([
       '/agents/codex',


### PR DESCRIPTION
## Purpose

xangi setup で antigravity を用いる場合、interacrive optionがないため、セットアップに失敗する。
```bash
$ npm run xangi setup
# Antigravity を選択
Error: unexpected argument "xangiのセットアップを始めます。最初に /tmp/xangi-onboarding-5BqQAt/instructions.md を読み、その指示に従って日本語で一問ずつ案内してください。".
Prompts are read only from -p/--print, -i/--prompt-interactive, or stdin, so this argument would have been ignored.
Error: Antigravityのオンボーディングが終了コード2で終了しました
```

## Effect

antigravity でinteractiveに渡すオプションを追加

## Test

```bash
$ npm run xangi setup
# Antigravity を選択

      ▄▀▀▄        Antigravity CLI 1.1.22
     ▀▀▀▀▀▀       example[at]gmail.com (Google AI Pro)
    ▀▀▀▀▀▀▀▀      Gemini 3.1 Pro (High)
   ▄▀▀    ▀▀▄     ~
  ▄▀▀      ▀▀▄

────────────────────────────────────────────────────────────
> xangiのセットアップを始めます。最初に /tmp/xangi-onboarding-cLFKMh/instructions.md
  を読み、その指示に従って日本語で一問ずつ案内してください。

▸ Thought for 5s, 200 tokens
  Prioritizing Tool Specificity

● Read(/tmp/xangi-onboarding-cLFKMh/instructions.md) (ctrl+o to expand)

▸ Thought for 6s, 250 tokens
  Initiating Xangi Onboarding
  xangiのセットアップを開始します。
```

Antigravityを用いたセットアップが開始される
## Test Environment

### Hardware

Arch Linux

### Software(Library)

node v24.18.1

## Memo
