### PR TITLE
feat(monitor): Antigravity利用枠に期間長をマッピングし目安残・ペース表示に対応

### DIFF
--- a/src/usage-monitor.ts
+++ b/src/usage-monitor.ts
@@ -309,7 +309,10 @@ export function parseCopilotQuota(result: unknown, now = Date.now()): AccountUsa
   return windows.length ? [{ id: 'copilot', label: 'GitHub Copilot', windows }] : [];
 }
 
-export function parseAntigravityStatus(payload: unknown): {
+export function parseAntigravityStatus(
+  payload: unknown,
+  now?: number
+): {
   groups: AccountUsageGroup[];
   conversationId?: string;
   conversationTitle?: string;
@@ -367,12 +370,13 @@ export function parseAntigravityStatus(payload: unknown): {
   for (const [id, quota] of Object.entries(status?.quota ?? {})) {
     if (typeof quota.remaining_fraction !== 'number') continue;
     const resetMs = quota.reset_time ? Date.parse(quota.reset_time) : Number.NaN;
+    const expired = now !== undefined && Number.isFinite(resetMs) && resetMs <= now;
     const known = knownQuotaBuckets[id];
     const window = {
       label: known?.windowLabel ?? (/(?:^|-)weekly(?:-|$)/i.test(id) ? '週次' : id),
-      usedPercent: Number(
-        Math.min(100, Math.max(0, (1 - quota.remaining_fraction) * 100)).toFixed(6)
-      ),
+      usedPercent: expired
+        ? 0
+        : Number(Math.min(100, Math.max(0, (1 - quota.remaining_fraction) * 100)).toFixed(6)),
       windowDurationMins:
         known?.windowDurationMins ??
         (/(?:^|-)weekly(?:-|$)/i.test(id)
@@ -380,7 +384,7 @@ export function parseAntigravityStatus(payload: unknown): {
           : /(?:^|-)5h(?:-|$)/i.test(id)
             ? 300
             : undefined),
-      resetsAt: Number.isFinite(resetMs) ? resetMs / 1000 : undefined,
+      resetsAt: Number.isFinite(resetMs) && !expired ? resetMs / 1000 : undefined,
     };
     if (!known) {
       fallbackGroups.push({
@@ -547,7 +551,7 @@ async function readAntigravityUsage(): Promise<AccountUsageProvider> {
   const dataDir =
     process.env.DATA_DIR || resolve(process.env.WORKSPACE_PATH || process.cwd(), '.xangi');
   const payload = JSON.parse(await readFile(join(dataDir, 'antigravity-status.json'), 'utf8'));
-  const parsed = parseAntigravityStatus(payload);
+  const parsed = parseAntigravityStatus(payload, Date.now());
   const groups = parsed.groups;
   applyAntigravitySessionUsage(parsed);
   if (!groups.length) throw new Error('Antigravity status payload has no quota');

--- a/src/usage-monitor.ts
+++ b/src/usage-monitor.ts
@@ -369,12 +369,17 @@ export function parseAntigravityStatus(payload: unknown): {
     const resetMs = quota.reset_time ? Date.parse(quota.reset_time) : Number.NaN;
     const known = knownQuotaBuckets[id];
     const window = {
-      label: known?.windowLabel ?? (/week/i.test(id) ? '週次' : id),
+      label: known?.windowLabel ?? (/(?:^|-)weekly(?:-|$)/i.test(id) ? '週次' : id),
       usedPercent: Number(
         Math.min(100, Math.max(0, (1 - quota.remaining_fraction) * 100)).toFixed(6)
       ),
       windowDurationMins:
-        known?.windowDurationMins ?? (/week/i.test(id) ? 10_080 : /5h/i.test(id) ? 300 : undefined),
+        known?.windowDurationMins ??
+        (/(?:^|-)weekly(?:-|$)/i.test(id)
+          ? 10_080
+          : /(?:^|-)5h(?:-|$)/i.test(id)
+            ? 300
+            : undefined),
       resetsAt: Number.isFinite(resetMs) ? resetMs / 1000 : undefined,
     };
     if (!known) {

--- a/src/usage-monitor.ts
+++ b/src/usage-monitor.ts
@@ -319,30 +319,40 @@ export function parseAntigravityStatus(payload: unknown): {
   const status = payload as AntigravityStatusPayload;
   const knownQuotaBuckets: Record<
     string,
-    { groupId: string; groupLabel: string; windowLabel: string; order: number }
+    {
+      groupId: string;
+      groupLabel: string;
+      windowLabel: string;
+      windowDurationMins: number;
+      order: number;
+    }
   > = {
     'gemini-5h': {
       groupId: 'gemini',
       groupLabel: 'Geminiモデル',
       windowLabel: '5時間',
+      windowDurationMins: 300,
       order: 0,
     },
     'gemini-weekly': {
       groupId: 'gemini',
       groupLabel: 'Geminiモデル',
       windowLabel: '週次',
+      windowDurationMins: 10_080,
       order: 1,
     },
     '3p-5h': {
       groupId: 'third-party',
       groupLabel: 'サードパーティモデル',
       windowLabel: '5時間',
+      windowDurationMins: 300,
       order: 0,
     },
     '3p-weekly': {
       groupId: 'third-party',
       groupLabel: 'サードパーティモデル',
       windowLabel: '週次',
+      windowDurationMins: 10_080,
       order: 1,
     },
   };
@@ -363,6 +373,8 @@ export function parseAntigravityStatus(payload: unknown): {
       usedPercent: Number(
         Math.min(100, Math.max(0, (1 - quota.remaining_fraction) * 100)).toFixed(6)
       ),
+      windowDurationMins:
+        known?.windowDurationMins ?? (/week/i.test(id) ? 10_080 : /5h/i.test(id) ? 300 : undefined),
       resetsAt: Number.isFinite(resetMs) ? resetMs / 1000 : undefined,
     };
     if (!known) {

--- a/tests/usage-monitor.test.ts
+++ b/tests/usage-monitor.test.ts
@@ -185,6 +185,34 @@ describe('usage monitor parsers', () => {
     });
   });
 
+  it('infers window durations only from delimited Antigravity quota bucket tokens', () => {
+    const { groups } = parseAntigravityStatus({
+      quota: {
+        'future-weekly': { remaining_fraction: 1 },
+        'future-5h': { remaining_fraction: 1 },
+        'future-15h': { remaining_fraction: 1 },
+        weekend: { remaining_fraction: 1 },
+      },
+    });
+
+    expect(
+      Object.fromEntries(
+        groups.map((group) => [
+          group.id,
+          {
+            label: group.windows[0]?.label,
+            windowDurationMins: group.windows[0]?.windowDurationMins,
+          },
+        ])
+      )
+    ).toEqual({
+      'future-weekly': { label: '週次', windowDurationMins: 10_080 },
+      'future-5h': { label: 'future-5h', windowDurationMins: 300 },
+      'future-15h': { label: 'future-15h', windowDurationMins: undefined },
+      weekend: { label: 'weekend', windowDurationMins: undefined },
+    });
+  });
+
   it('keeps unknown Antigravity quota buckets and ignores unavailable cost', () => {
     expect(
       parseAntigravityStatus({

--- a/tests/usage-monitor.test.ts
+++ b/tests/usage-monitor.test.ts
@@ -124,11 +124,13 @@ describe('usage monitor parsers', () => {
             {
               label: '5時間',
               usedPercent: 5,
+              windowDurationMins: 300,
               resetsAt: Date.parse('2026-08-31T08:00:06.000Z') / 1000,
             },
             {
               label: '週次',
               usedPercent: 9.64064,
+              windowDurationMins: 10_080,
               resetsAt: Date.parse('2026-09-01T00:00:00.000Z') / 1000,
             },
           ],
@@ -141,16 +143,45 @@ describe('usage monitor parsers', () => {
             {
               label: '5時間',
               usedPercent: 0,
+              windowDurationMins: 300,
               resetsAt: Date.parse('2026-08-31T08:00:06.000Z') / 1000,
             },
             {
               label: '週次',
               usedPercent: 0,
+              windowDurationMins: 10_080,
               resetsAt: Date.parse('2026-09-02T00:00:00.000Z') / 1000,
             },
           ],
         },
       ],
+    });
+  });
+
+  it('maps window durations for known Antigravity quota buckets', () => {
+    const { groups } = parseAntigravityStatus({
+      quota: {
+        'gemini-5h': { remaining_fraction: 1 },
+        'gemini-weekly': { remaining_fraction: 1 },
+        '3p-5h': { remaining_fraction: 1 },
+        '3p-weekly': { remaining_fraction: 1 },
+      },
+    });
+
+    expect(
+      Object.fromEntries(
+        groups.flatMap((group) =>
+          group.windows.map((window) => [
+            `${group.id}:${window.label}`,
+            window.windowDurationMins,
+          ])
+        )
+      )
+    ).toEqual({
+      'gemini:5時間': 300,
+      'gemini:週次': 10_080,
+      'third-party:5時間': 300,
+      'third-party:週次': 10_080,
     });
   });
 

--- a/tests/usage-monitor.test.ts
+++ b/tests/usage-monitor.test.ts
@@ -185,6 +185,29 @@ describe('usage monitor parsers', () => {
     });
   });
 
+  it('clears stale Antigravity usage after its reported reset time', () => {
+    const { groups } = parseAntigravityStatus(
+      {
+        quota: {
+          'gemini-weekly': {
+            remaining_fraction: 0.7779,
+            reset_time: '2026-09-11T05:15:22.000Z',
+          },
+        },
+      },
+      Date.parse('2026-09-11T06:29:00.000Z')
+    );
+
+    expect(groups[0]?.windows).toEqual([
+      {
+        label: '週次',
+        usedPercent: 0,
+        windowDurationMins: 10_080,
+        resetsAt: undefined,
+      },
+    ]);
+  });
+
   it('infers window durations only from delimited Antigravity quota bucket tokens', () => {
     const { groups } = parseAntigravityStatus({
       quota: {


### PR DESCRIPTION
## 概要

Web UI Monitor（`/monitor`）の「AI利用量」において、CodexやClaude Codeと同様に、Antigravity（Geminiモデル／サードパーティモデル）でも時間経過ペースラインと「目安残 XX%」を表示できるようにします。

## 背景・課題

- Antigravityのstatusline JSONは`gemini-5h`、`gemini-weekly`、`3p-5h`、`3p-weekly`というバケット名とリセット日時を持ちますが、期間長を持ちません。
- 期間長がないとMonitor UIのペース計算条件を満たさず、目安残と時間経過マーカーを表示できませんでした。
- statuslineが更新されないままリセット時刻を過ぎると、期限切れの使用率とリセット時刻が残る場合がありました。

## 変更内容

- 既知の5時間枠へ300分、週次枠へ10,080分の期間長を設定
- 未知のバケット名は、`weekly`または`5h`が区切られたトークンの場合だけ期間長を推定
- `15h`や`weekend`を5時間枠・週次枠と誤判定しないよう修正
- `reset_time`を過ぎた利用枠は使用率を0%へ戻し、期限切れのリセット時刻と目安マーカーを表示しない
- 上記の境界条件を固定する回帰テストを追加

## 期間の根拠

- Antigravity公式のModels／Plansは、週次制限と5時間ごとのリフレッシュを記載
- 公式statusline schemaの実例も`gemini-weekly`と`reset_time`を提供

## 検証

- [x] 関連74テスト
- [x] `npm run typecheck`
- [x] `npm run lint`
- [x] `npm run format:check`
- [x] `npm run build`
- [x] 運用環境へ反映・再起動し、期限切れGemini週次枠が`usedPercent: 0`となり、過去の`resetsAt`が返らないことを`/api/usage`で確認
- [x] Monitor画面を実機確認
